### PR TITLE
chore: relax lighthouse performance threshold

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -8,7 +8,7 @@
         },
         "assert": {
             "assertions": {
-                "categories:performance": ["error", { "minScore": 0.95 }]
+                "categories:performance": ["error", { "minScore": 0.85 }]
             }
         }
     }

--- a/budget.lighthouse.json
+++ b/budget.lighthouse.json
@@ -12,6 +12,6 @@
             { "resourceType": "render-blocking-resources", "budget": 1 },
             { "resourceType": "unused-css-rules", "budget": 0 }
         ],
-        "scores": [{ "metric": "performance", "budget": 0.95 }]
+        "scores": [{ "metric": "performance", "budget": 0.85 }]
     }
 ]


### PR DESCRIPTION
## Summary
- lower CI performance assertion to 0.85
- update lighthouse budget to match

## Testing
- `npm test` *(fails: Process from config.webServer exited early)*
- `npm run lint`
- `npm run qa` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1b2facf483289b113f19d35d9f18