### PR TITLE
Run Playwright accessibility tests in light and dark modes

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,16 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
     testDir: "./tests",
     use: { baseURL: "http://localhost:3000" },
+    projects: [
+        {
+            name: "light",
+            use: { colorScheme: "light" },
+        },
+        {
+            name: "dark",
+            use: { colorScheme: "dark" },
+        },
+    ],
     webServer: {
         command: "npm run build:next && npm run start",
         url: "http://localhost:3000",


### PR DESCRIPTION
## Summary
- run Playwright tests against light and dark color schemes to validate accessibility in both themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a1b15398483289f587db52ad4fe87