### PR TITLE
Reduce font downloads to improve Lighthouse performance

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,16 +4,24 @@ import { Lexend_Deca, Roboto_Mono } from "next/font/google";
 import "@/styles/tokens.scss";
 import "@/styles/globals.scss";
 
+// Limit downloaded font weights to reduce font file size.
+// Only the normal (400) and semi-bold (600) weights are used across the
+// site, so we explicitly request those weights from Google Fonts. This
+// prevents the default variable font files from being included, trimming
+// several unnecessary woff2 files from the build and improving
+// Lighthouse performance scores.
 const header = Lexend_Deca({
     variable: "--font-header",
     subsets: ["latin"],
     display: "swap",
+    weight: ["400", "600"],
 });
 
 const body = Roboto_Mono({
     variable: "--font-body",
     subsets: ["latin"],
     display: "swap",
+    weight: ["400", "600"],
 });
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## Summary
- request the normal (400) and semi-bold (600) weights for Lexend Deca and Roboto Mono
- add documentation explaining performance benefit

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run lh:ci` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1fa1095c832883138ef090e070ed