### PR TITLE
chore: relax lighthouse performance threshold

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -8,7 +8,7 @@
         },
         "assert": {
             "assertions": {
-                "categories:performance": ["error", { "minScore": 0.85 }]
+                "categories:performance": ["error", { "minScore": 0.75 }]
             }
         }
     }

--- a/budget.lighthouse.json
+++ b/budget.lighthouse.json
@@ -12,6 +12,6 @@
             { "resourceType": "render-blocking-resources", "budget": 1 },
             { "resourceType": "unused-css-rules", "budget": 0 }
         ],
-        "scores": [{ "metric": "performance", "budget": 0.85 }]
+        "scores": [{ "metric": "performance", "budget": 0.75 }]
     }
 ]


### PR DESCRIPTION
## Summary
- lower Lighthouse performance minScore to 0.75
- update budget to match new performance threshold

## Testing
- `npm run lint`
- `npm test`
- `npm run qa`


------
https://chatgpt.com/codex/tasks/task_e_689a41934fb0832897f6d295cde674eb