### PR TITLE
fix: cache Playwright browsers in GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
         name: Test
         runs-on: ubuntu-latest
         env:
-            PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+            PLAYWRIGHT_BROWSERS_PATH: ${{ env.HOME }}/.cache/ms-playwright
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -35,7 +35,7 @@ jobs:
             - name: Cache Playwright browsers
               uses: actions/cache@v4
               with:
-                  path: ~/.cache/ms-playwright
+                  path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
                   key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-playwright-


### PR DESCRIPTION
## Summary
- ensure Playwright cache path uses HOME directory
- reuse env variable when caching Playwright browsers

## Testing
- `npm test` (fails: browserType.launch: Executable doesn't exist)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4f2c47248328b294774a1c0f3374