### PR TITLE
Fix invalid env reference in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
         name: Test
         runs-on: ubuntu-latest
         env:
-            PLAYWRIGHT_BROWSERS_PATH: ${{ env.HOME }}/.cache/ms-playwright
+            PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         steps:
             - name: Checkout
               uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- avoid using undefined env.HOME in test workflow

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a52062028832885ee0da2e799cadf