### PR TITLE
Increase tap target size for footer and social links

### DIFF
--- a/app/page.module.scss
+++ b/app/page.module.scss
@@ -120,11 +120,16 @@
     flex-wrap: wrap;
 }
 
-.footerNav a {
-    text-decoration: none;
-    padding: var(--space-xs) var(--space-s);
-}
-
+.footerNav a,
 .social a {
     padding: var(--space-xs) var(--space-s);
+    min-block-size: 44px;
+    min-inline-size: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.footerNav a {
+    text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- expand footer and social link tap targets to meet 44px minimum

## Testing
- `npm run lint:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a53380eb08328b3925dd947ca30eb