### PR TITLE
feat: add company number to footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -232,6 +232,10 @@ export default function Page() {
                             </li>
                         </ul>
                     </nav>
+                    <p>
+                        Lapidist Ltd, registered in Scotland. Company number
+                        SC549211.
+                    </p>
                     <p>© {new Date().getFullYear()} Brett Dorrans.</p>
                     <ul className={styles.social}>
                         <li>

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -4,6 +4,9 @@ import AxeBuilder from "@axe-core/playwright";
 test("home renders with basic a11y and performance", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("h1")).toContainText("design systems");
+    await expect(page.locator("footer")).toContainText(
+        "Company number SC549211",
+    );
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
     const nav = await page.evaluate(


### PR DESCRIPTION
## Summary
- show Lapidist Ltd registration and company number in the site footer
- check for the company number in smoke test

## Testing
- `npm run lint`
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_689a55ff370c832888b3c9793ddb0c89