### PR TITLE
Increase footer link touch targets

### DIFF
--- a/app/page.module.scss
+++ b/app/page.module.scss
@@ -114,17 +114,20 @@
     padding: 0;
     display: flex;
     gap: var(--space-s);
+    align-items: center;
 }
 
 .footerNav {
     flex-wrap: wrap;
 }
 
-.footerNav a {
-    text-decoration: none;
-    padding: var(--space-xs) var(--space-s);
-}
-
+.footerNav a,
 .social a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-block-size: 44px;
+    min-inline-size: 44px;
+    text-decoration: none;
     padding: var(--space-xs) var(--space-s);
 }


### PR DESCRIPTION
## Summary
- ensure footer and social links meet 44px minimum tap target size and align flex items

## Testing
- `npm run lint`
- `npm test` *(fails: Error: Process from config.webServer exited early.)*

------
https://chatgpt.com/codex/tasks/task_e_689a583562f08328983f059f35e0648f