### PR TITLE
refactor: use tokens for color references

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,10 +28,7 @@ export const viewport: Viewport = {
     colorScheme: "light dark",
     width: "device-width",
     initialScale: 1,
-    themeColor: [
-        { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-        { media: "(prefers-color-scheme: dark)", color: "#090909" },
-    ],
+    themeColor: "var(--bg)",
 };
 
 export const metadata: Metadata = {
@@ -87,14 +84,18 @@ export default function RootLayout({
                 <meta
                     name="theme-color"
                     media="(prefers-color-scheme: light)"
-                    content="#ffffff"
+                    content="var(--bg)"
                 />
                 <meta
                     name="theme-color"
                     media="(prefers-color-scheme: dark)"
-                    content="#090909"
+                    content="var(--bg)"
                 />
-                <link rel="mask-icon" href="/mask-icon.svg" color="#6847ff" />
+                <link
+                    rel="mask-icon"
+                    href="/mask-icon.svg"
+                    color="var(--mask-icon)"
+                />
             </head>
             <body className={`${header.variable} ${body.variable}`}>
                 <a href="#main" className="skip-link">

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { tokens } from "@/lib/tokens";
 
 export const dynamic = "force-static";
 export const size = { width: 1200, height: 630 };
@@ -14,8 +15,8 @@ export default function OGImage() {
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "center",
-                    background: "#000",
-                    color: "#fff",
+                    background: tokens.black,
+                    color: tokens.white,
                     padding: "80px",
                     fontFamily: "sans-serif",
                     backgroundImage:

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { tokens } from "@/lib/tokens";
 
 export const dynamic = "force-static";
 export const size = { width: 1600, height: 900 };
@@ -14,8 +15,8 @@ export default function TwitterImage() {
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "center",
-                    background: "#000",
-                    color: "#fff",
+                    background: tokens.black,
+                    color: tokens.white,
                     padding: "96px",
                     fontFamily: "sans-serif",
                     backgroundImage:

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,0 +1,7 @@
+export const tokens = {
+    white: "#ffffff",
+    black: "#000000",
+    maskIcon: "#6847ff",
+    bgLight: "#ffffff",
+    bgDark: "#090909",
+} as const;

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,8 +15,8 @@
             "purpose": "maskable"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+    "theme_color": "#fff",
+    "background_color": "#fff",
     "display": "standalone",
     "start_url": "/",
     "scope": "/"

--- a/styles/tokens.scss
+++ b/styles/tokens.scss
@@ -10,9 +10,13 @@
     --border: #d0d0d0;
     --muted: #e5e5e5;
 
+    --white: #ffffff;
+    --black: #000000;
+
     /* brand */
     --primary: #4b6be8;
     --primary-contrast: #ffffff;
+    --mask-icon: #6847ff;
 
     /* semantic */
     --success: #1b9a59;
@@ -74,8 +78,11 @@
         --text-subtle: oklch(55% 0 0deg);
         --border: oklch(86% 0.02 95deg);
         --muted: oklch(93% 0.01 95deg);
+        --white: oklch(100% 0 0deg);
+        --black: oklch(0% 0 0deg);
         --primary: oklch(57% 0.19 269deg);
         --primary-contrast: oklch(100% 0 0deg);
+        --mask-icon: oklch(55% 0.25 282deg);
         --success: oklch(67% 0.15 154deg);
         --warning: oklch(83% 0.16 83deg);
         --danger: oklch(62% 0.22 27deg);


### PR DESCRIPTION
## Summary
- add white, black, and mask icon color tokens
- use shared tokens in layout meta tags and social image generators
- normalize PWA manifest colours

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a58473e908328be91d3aa48b5f05d