### PR TITLE
fix availability phrase in structured data

### DIFF
--- a/lib/structuredData.ts
+++ b/lib/structuredData.ts
@@ -98,7 +98,7 @@ export function buildStructuredData() {
                         name: "Are you taking on new projects?",
                         acceptedAnswer: {
                             "@type": "Answer",
-                            text: "Yes, I available for new roles or contract projects. Get in touch.",
+                            text: "Yes, I am available for new roles or contract projects. Get in touch.",
                         },
                     },
                 ],


### PR DESCRIPTION
## Summary
- correct availability text in structured data

## Testing
- `npm run lint`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689a5f51314483289bab25aed70647b4