### PR TITLE
refine services and approach copy

### DIFF
--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -8,16 +8,16 @@ export default function Approach() {
                 <h2>My Approach</h2>
                 <ol className={styles.steps}>
                     <li>
-                        <strong>Audit</strong> &rarr; baseline current UI
-                        workflows.
+                        <strong>Audit</strong> &rarr; understand your current
+                        interface and spot opportunities.
                     </li>
                     <li>
-                        <strong>Prototype</strong> &rarr; prove value with
-                        tokens, components, culture.
+                        <strong>Prototype</strong> &rarr; show early
+                        improvements and gather feedback.
                     </li>
                     <li>
-                        <strong>Rollout</strong> &rarr; ship, track adoption,
-                        close gaps.
+                        <strong>Rollout</strong> &rarr; launch, measure
+                        adoption and refine.
                     </li>
                 </ol>
             </Container>

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -13,31 +13,29 @@ export default function Services() {
                         highlight
                         footer={<p>Timeline: 2-3 sprints</p>}
                     >
-                        <p>For product teams needing momentum.</p>
-                        <p>From audit to adoptable components in weeks.</p>
+                        <p>Launch a production-ready design system in weeks.</p>
+                        <p>Give your product team the momentum it needs.</p>
                     </Card>
                     <Card
                         title="System Audit & Roadmap"
                         footer={<p>Timeline: 2-3 sprints</p>}
                     >
-                        <p>For orgs with assets but no strategy.</p>
-                        <p>Build a pragmatic plan to evolve what exists.</p>
+                        <p>Turn your existing assets into a clear system strategy.</p>
+                        <p>Receive a practical roadmap to grow what you have.</p>
                     </Card>
                     <Card
                         title="Hands-on Build"
                         footer={<p>Timeline: 4–8 sprints</p>}
                     >
-                        <p>For teams lacking capacity.</p>
-                        <p>Patterns, tools, processes that endure and scale.</p>
+                        <p>Ship reliable system foundations without diverting your team.</p>
+                        <p>Gain patterns and processes that last.</p>
                     </Card>
                     <Card
                         title="Advisory & Team Uplift"
                         footer={<p>Timeline: ongoing</p>}
                     >
-                        <p>For growing teams.</p>
-                        <p>
-                            Standards, coaching and reviews that raise the bar.
-                        </p>
+                        <p>Grow your team&apos;s capabilities with ongoing guidance.</p>
+                        <p>Raise quality through tailored standards, coaching and reviews.</p>
                     </Card>
                 </div>
             </Container>


### PR DESCRIPTION
## Summary
- rewrite service blurbs to highlight outcomes and avoid jargon
- streamline approach steps around client benefits

## Testing
- `npm run format` *(fails: Code style issues found in 13 files)*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@/app/(assets)/images/abstract-2.svg')*
- `npx playwright install`
- `npx playwright install-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af4c41e5c83289b101a9a21a20e73