### PR TITLE
feat: add region landmarks to sections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import dynamic from "next/dynamic";
-
+import Footer from "@/components/Footer/Footer";
 import Hero from "@/components/Hero/Hero";
+import { buildStructuredData } from "./structuredData";
+
 const Stats = dynamic(() => import("@/components/Stats/Stats"));
 const ProblemToSolution = dynamic(
     () => import("@/components/ProblemToSolution/ProblemToSolution"),
@@ -12,9 +14,6 @@ const CaseExample = dynamic(
     () => import("@/components/CaseExample/CaseExample"),
 );
 const Contact = dynamic(() => import("@/components/Contact/Contact"));
-import Footer from "@/components/Footer/Footer";
-
-import { buildStructuredData } from "./structuredData";
 
 export default function Page() {
     const structuredData = buildStructuredData();
@@ -26,14 +25,16 @@ export default function Page() {
                     __html: JSON.stringify(structuredData),
                 }}
             />
-            <Hero />
-            <Stats />
-            <ProblemToSolution />
-            <Services />
-            <Approach />
-            <Pledge />
-            <CaseExample />
-            <Contact />
+            <main>
+                <Hero />
+                <Stats />
+                <ProblemToSolution />
+                <Services />
+                <Approach />
+                <Pledge />
+                <CaseExample />
+                <Contact />
+            </main>
             <Footer />
         </>
     );

--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -3,9 +3,13 @@ import styles from "./Approach.module.scss";
 
 export default function Approach() {
     return (
-        <section style={{ contentVisibility: "auto" }}>
+        <section
+            role="region"
+            aria-labelledby="approach-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
-                <h2>My Approach</h2>
+                <h2 id="approach-heading">My Approach</h2>
                 <ol className={styles.steps}>
                     <li>
                         <strong>Audit</strong> &rarr; baseline current UI

--- a/components/CaseExample/CaseExample.tsx
+++ b/components/CaseExample/CaseExample.tsx
@@ -1,14 +1,18 @@
 import Image, { type StaticImageData } from "next/image";
+import abstract2 from "@/app/(assets)/images/abstract-2.svg";
 import Card from "@/components/Card/Card";
 import Container from "@/components/Container/Container";
 import styles from "./CaseExample.module.scss";
-import abstract2 from "@/app/(assets)/images/abstract-2.svg";
 
 export default function CaseExample() {
     return (
-        <section style={{ contentVisibility: "auto" }}>
+        <section
+            role="region"
+            aria-labelledby="case-example-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
-                <h2>Case example</h2>
+                <h2 id="case-example-heading">Case example</h2>
                 <Card
                     className={styles.caseExample}
                     title="Global fintech"

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -4,9 +4,14 @@ import styles from "./Contact.module.scss";
 
 export default function Contact() {
     return (
-        <section id="contact" style={{ contentVisibility: "auto" }}>
+        <section
+            id="contact"
+            role="region"
+            aria-labelledby="contact-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
-                <h2>Ready to ship?</h2>
+                <h2 id="contact-heading">Ready to ship?</h2>
                 <div className={styles.ctaGroup}>
                     <Button href="mailto:hello@lapidist.net">
                         Book a 20-min discovery call

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,13 +1,17 @@
-import Container from "@/components/Container/Container";
 import Button from "@/components/Button/Button";
+import Container from "@/components/Container/Container";
 import styles from "./Hero.module.scss";
 
 export default function Hero() {
     return (
-        <section className={styles.hero}>
+        <section
+            className={styles.hero}
+            role="region"
+            aria-labelledby="hero-heading"
+        >
             <Container size="l">
                 <div className={styles.ctaGroup}>
-                    <h1 className={styles.heroTitle}>
+                    <h1 id="hero-heading" className={styles.heroTitle}>
                         Ship design systems teams trust.
                     </h1>
                     <p className={styles.heroIntro}>

--- a/components/Pledge/Pledge.tsx
+++ b/components/Pledge/Pledge.tsx
@@ -1,10 +1,20 @@
 import Container from "@/components/Container/Container";
+import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
 import styles from "./Pledge.module.scss";
 
 export default function Pledge() {
     return (
-        <section style={{ contentVisibility: "auto" }}>
+        <section
+            role="region"
+            aria-labelledby="pledge-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
+                <h2 id="pledge-heading">
+                    <VisuallyHidden>
+                        Accessibility &amp; Performance pledge
+                    </VisuallyHidden>
+                </h2>
                 <details>
                     <summary>
                         View my Accessibility &amp; Performance pledge

--- a/components/ProblemToSolution/ProblemToSolution.tsx
+++ b/components/ProblemToSolution/ProblemToSolution.tsx
@@ -3,9 +3,15 @@ import styles from "./ProblemToSolution.module.scss";
 
 export default function ProblemToSolution() {
     return (
-        <section style={{ contentVisibility: "auto" }}>
+        <section
+            role="region"
+            aria-labelledby="problem-to-solution-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
-                <h2>From problem to solution</h2>
+                <h2 id="problem-to-solution-heading">
+                    From problem to solution
+                </h2>
                 <ul className={styles.steps}>
                     <li>Tame design drift with scalable tokens.</li>
                     <li>Cut PR nitpicks via shared components.</li>

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -4,9 +4,14 @@ import styles from "./Services.module.scss";
 
 export default function Services() {
     return (
-        <section id="services" style={{ contentVisibility: "auto" }}>
+        <section
+            id="services"
+            role="region"
+            aria-labelledby="services-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
-                <h2>Signature services</h2>
+                <h2 id="services-heading">Signature services</h2>
                 <div className={styles.cards}>
                     <Card
                         title="Design System Bootstrap"

--- a/components/Stats/Stats.tsx
+++ b/components/Stats/Stats.tsx
@@ -1,11 +1,19 @@
 import Container from "@/components/Container/Container";
 import Stat from "@/components/Stat/Stat";
+import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
 import styles from "./Stats.module.scss";
 
 export default function Stats() {
     return (
-        <section style={{ contentVisibility: "auto" }}>
+        <section
+            role="region"
+            aria-labelledby="stats-heading"
+            style={{ contentVisibility: "auto" }}
+        >
             <Container>
+                <h2 id="stats-heading">
+                    <VisuallyHidden>Stats</VisuallyHidden>
+                </h2>
                 <div className={styles.stats}>
                     <Stat value="15+ years" label="engineering expertise" />
                     <Stat value="Enterprise" label="scalable fintech apps" />


### PR DESCRIPTION
## Summary
- label each homepage section with `role="region"` and an `aria-labelledby` heading
- ensure Hero provides the only `<h1>` and wrap remaining sections in `<main>`
- add hidden headings where necessary for Stats and Pledge

## Testing
- `npm test` *(fails: accessibility violations)*
- `npm run lint` *(fails: 151 problems)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689af4aafed88328809000b3f7bc62a5