### PR TITLE
Fix a11y test by removing nested main element

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,16 +25,14 @@ export default function Page() {
                     __html: JSON.stringify(structuredData),
                 }}
             />
-            <main>
-                <Hero />
-                <Stats />
-                <ProblemToSolution />
-                <Services />
-                <Approach />
-                <Pledge />
-                <CaseExample />
-                <Contact />
-            </main>
+            <Hero />
+            <Stats />
+            <ProblemToSolution />
+            <Services />
+            <Approach />
+            <Pledge />
+            <CaseExample />
+            <Contact />
             <Footer />
         </>
     );


### PR DESCRIPTION
## Summary
- avoid duplicate main landmarks by removing nested `<main>` in page

## Testing
- `npm run test:install-browsers`
- `npm test`
- `npm run lint` *(fails: 151 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689afcd947f8832895d1a3d6ab1a3e12