### PR TITLE
refactor css for maintainability

### DIFF
--- a/components/Approach/Approach.module.scss
+++ b/components/Approach/Approach.module.scss
@@ -1,20 +1,5 @@
+@use "../../styles/mixins" as *;
+
 .steps {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-m);
-    counter-reset: step;
-}
-
-.steps li {
-    list-style-type: none;
-    counter-increment: step;
-    padding-inline-start: var(--space-m);
-    position: relative;
-}
-
-.steps li::before {
-    content: counter(step) ".";
-    position: absolute;
-    inset-inline-start: calc(var(--space-l) * -1);
-    font-weight: 600;
+    @include steps;
 }

--- a/components/CaseExample/CaseExample.module.scss
+++ b/components/CaseExample/CaseExample.module.scss
@@ -1,3 +1,3 @@
 .caseExample {
-    margin-top: var(--space-l);
+    margin-block-start: var(--space-l);
 }

--- a/components/Contact/Contact.module.scss
+++ b/components/Contact/Contact.module.scss
@@ -1,7 +1,5 @@
+@use "../../styles/mixins" as *;
+
 .ctaGroup {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-s);
-    justify-content: center;
-    margin-block-start: var(--space-2xl);
+    @include cta-group;
 }

--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -1,3 +1,5 @@
+@use "../../styles/mixins" as *;
+
 .hero {
     text-align: center;
 }
@@ -15,11 +17,7 @@
 }
 
 .ctaGroup {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-s);
-    justify-content: center;
-    margin-block-start: var(--space-2xl);
+    @include cta-group;
 }
 
 .cta {

--- a/components/Pledge/Pledge.module.scss
+++ b/components/Pledge/Pledge.module.scss
@@ -6,7 +6,7 @@
 
 .checklist div {
     display: flex;
-    margin-top: var(--space-xs);
+    margin-block-start: var(--space-xs);
     gap: var(--space-s);
 }
 

--- a/components/ProblemToSolution/ProblemToSolution.module.scss
+++ b/components/ProblemToSolution/ProblemToSolution.module.scss
@@ -1,20 +1,5 @@
+@use "../../styles/mixins" as *;
+
 .steps {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-m);
-    counter-reset: step;
-}
-
-.steps li {
-    list-style-type: none;
-    counter-increment: step;
-    padding-inline-start: var(--space-m);
-    position: relative;
-}
-
-.steps li::before {
-    content: counter(step) ".";
-    position: absolute;
-    inset-inline-start: calc(var(--space-l) * -1);
-    font-weight: 600;
+    @include steps;
 }

--- a/components/Services/Services.module.scss
+++ b/components/Services/Services.module.scss
@@ -1,7 +1,7 @@
 .cards {
     display: grid;
     gap: var(--space-xl);
-    margin-top: var(--space-l);
+    margin-block-start: var(--space-l);
 }
 
 @container (min-width:50rem) {

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,0 +1,28 @@
+@mixin steps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-m);
+    counter-reset: step;
+
+    li {
+        list-style-type: none;
+        counter-increment: step;
+        padding-inline-start: var(--space-m);
+        position: relative;
+
+        &::before {
+            content: counter(step) ".";
+            position: absolute;
+            inset-inline-start: calc(var(--space-l) * -1);
+            font-weight: 600;
+        }
+    }
+}
+
+@mixin cta-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-s);
+    justify-content: center;
+    margin-block-start: var(--space-2xl);
+}


### PR DESCRIPTION
## Summary
- centralize repeated list and CTA group styles in a shared mixin file
- replace hard-coded margins with logical properties for direction-aware spacing

## Testing
- `npm run lint`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689afc871f088328a2304a8db2cb68a4