### PR TITLE
Refactor Stat component to use definition lists

### DIFF
--- a/components/Stat/Stat.module.scss
+++ b/components/Stat/Stat.module.scss
@@ -7,27 +7,27 @@
     gap: var(--space-2xs);
 }
 
-.value {
+.stat dt {
     font-size: var(--step-2);
     font-weight: 600;
     font-variant-numeric: tabular-nums;
 }
 
-.label {
+.stat dd {
     font-size: var(--step-negative-1);
     color: var(--text-subtle);
 }
 
-.stat[data-size="lg"] .value {
+.stat[data-size="lg"] dt {
     font-size: var(--step-3);
 }
 
-.stat[data-size="lg"] .label {
+.stat[data-size="lg"] dd {
     font-size: var(--step-0);
 }
 
 @container section (max-width: 20rem) {
-    .value {
+    .stat dt {
         font-size: var(--step-1);
     }
 }

--- a/components/Stat/Stat.tsx
+++ b/components/Stat/Stat.tsx
@@ -1,4 +1,3 @@
-import { useId } from "react";
 import styles from "./Stat.module.scss";
 
 interface Props {
@@ -16,17 +15,14 @@ export default function Stat({
     size = "md",
     className,
 }: Props) {
-    const id = useId();
     const classes = [styles.stat, className].filter(Boolean).join(" ");
     return (
-        <div className={classes} data-size={size}>
-            <div className={styles.value} aria-describedby={id}>
+        <dl className={classes} data-size={size}>
+            <dt>
                 {value}
                 {suffix && <span aria-hidden="true">{suffix}</span>}
-            </div>
-            <div id={id} className={styles.label}>
-                {label}
-            </div>
-        </div>
+            </dt>
+            <dd>{label}</dd>
+        </dl>
     );
 }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -8,6 +8,12 @@ test("home renders with basic a11y and performance", async ({ page }) => {
         page.getByRole("heading", { level: 2, name: "Signature services" }),
     ).toBeVisible();
     await expect(page.locator("body")).toContainText("Company number SC549211");
+    const stats = page.locator("section[aria-labelledby='stats-heading'] dl");
+    await expect(stats).toHaveCount(3);
+    await expect(stats.first().locator("dt")).toHaveText("15+ years");
+    await expect(stats.first().locator("dd")).toHaveText(
+        "engineering expertise",
+    );
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
     const nav = await page.evaluate(


### PR DESCRIPTION
## Summary
- replace Stat wrapper with semantic `<dl>` and remove `useId`
- use `<dt>` for numeric value and `<dd>` for label
- style `dt`/`dd` in Stat.module.scss and update smoke test

## Testing
- `npm test`
- `npm run lint`
- `npm run format` *(fails: Code style issues found in 10 files)*

------
https://chatgpt.com/codex/tasks/task_e_689b04065e7c8328ba983d6a2068e9eb