### PR TITLE
feat: preload fonts and opengraph image

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { Lexend_Deca, Roboto_Mono } from "next/font/google";
-
 import "@/styles/tokens.scss";
 import "@/styles/globals.scss";
 
@@ -94,6 +93,12 @@ export default function RootLayout({
                     media="(prefers-color-scheme: dark)"
                     content="#090909"
                 />
+                <link
+                    rel="preconnect"
+                    href="https://fonts.gstatic.com"
+                    crossOrigin="anonymous"
+                />
+                <link rel="preload" as="image" href="/opengraph-image" />
                 <link rel="mask-icon" href="/mask-icon.svg" color="#6847ff" />
             </head>
             <body className={`${header.variable} ${body.variable}`}>


### PR DESCRIPTION
## Summary
- add preconnect to fonts.gstatic.com
- preload opengraph image in document head

## Testing
- `npm run lint`
- `npm run format` *(fails: code style issues found in 10 files)*
- `npm run typecheck`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689b03e05e908328bfd511312ef46c13