### PR TITLE
feat: expose button refs

### DIFF
--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import Button from "./Button";
 
@@ -32,4 +33,29 @@ export const Loading: Story = {
 
 export const AsLink: Story = {
     args: { href: "#" },
+};
+
+export const WithRef: Story = {
+    render: function WithRefStory(args) {
+        const ref = useRef<HTMLButtonElement>(null);
+
+        useEffect(() => {
+            ref.current?.focus();
+        }, []);
+
+        return <Button ref={ref} {...args} />;
+    },
+};
+
+export const AsLinkWithRef: Story = {
+    args: { href: "#" },
+    render: function AsLinkWithRefStory(args) {
+        const ref = useRef<HTMLAnchorElement>(null);
+
+        useEffect(() => {
+            ref.current?.focus();
+        }, []);
+
+        return <Button ref={ref} {...args} />;
+    },
 };

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,7 +1,9 @@
+import { forwardRef } from "react";
 import type {
     AnchorHTMLAttributes,
     ButtonHTMLAttributes,
     ReactNode,
+    Ref,
 } from "react";
 import styles from "./Button.module.scss";
 
@@ -22,47 +24,59 @@ type AnchorProps = BaseProps &
 
 type Props = ButtonProps | AnchorProps;
 
-export default function Button({
-    variant = "primary",
-    size = "md",
-    loading = false,
-    className,
-    children,
-    href,
-    ...rest
-}: Props) {
-    const classes = [styles.button, className].filter(Boolean).join(" ");
-    const data = {
-        "data-variant": variant,
-        "data-size": size,
-        "data-loading": loading,
-    } as const;
+const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
+    (
+        {
+            variant = "primary",
+            size = "md",
+            loading = false,
+            className,
+            children,
+            href,
+            ...rest
+        },
+        ref,
+    ) => {
+        const classes = [styles.button, className].filter(Boolean).join(" ");
+        const data = {
+            "data-variant": variant,
+            "data-size": size,
+            "data-loading": loading,
+        } as const;
 
-    if (href) {
+        if (href) {
+            return (
+                <a
+                    {...(rest as AnchorHTMLAttributes<HTMLAnchorElement>)}
+                    {...data}
+                    href={href}
+                    className={classes}
+                    aria-busy={loading || undefined}
+                    ref={ref as Ref<HTMLAnchorElement>}
+                >
+                    {children}
+                </a>
+            );
+        }
+
+        const buttonRest = rest as ButtonHTMLAttributes<HTMLButtonElement>;
+
         return (
-            <a
-                {...(rest as AnchorHTMLAttributes<HTMLAnchorElement>)}
+            <button
+                {...buttonRest}
+                type={buttonRest.type ?? "button"}
                 {...data}
-                href={href}
                 className={classes}
                 aria-busy={loading || undefined}
+                disabled={loading || buttonRest.disabled}
+                ref={ref as Ref<HTMLButtonElement>}
             >
                 {children}
-            </a>
+            </button>
         );
-    }
+    },
+);
 
-    const buttonRest = rest as ButtonHTMLAttributes<HTMLButtonElement>;
+Button.displayName = "Button";
 
-    return (
-        <button
-            {...buttonRest}
-            {...data}
-            className={classes}
-            aria-busy={loading || undefined}
-            disabled={loading || buttonRest.disabled}
-        >
-            {children}
-        </button>
-    );
-}
+export default Button;


### PR DESCRIPTION
## Summary
- forward Button refs to both `button` and `a` elements and default button type to `button`
- add Storybook examples demonstrating ref usage

## Testing
- `npm test`
- `npm run lint`
- `npm run format` *(fails: Code style issues found in 11 files)*

------
https://chatgpt.com/codex/tasks/task_e_689b03fe53908328a3fafd68116de5cc