### PR TITLE
feat: improve typography with variable fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 This repository lives at [lapidist.net](https://lapidist.net)
 
+## Typography
+
+The site uses variable fonts with optical sizing and slant configured via
+`font-variation-settings`. Design tokens are provided for line height and
+measure to keep text rhythm consistent:
+
+- `--font-opsz` – optical size axis
+- `--font-slnt` – slant axis
+- `--leading-tight` and `--leading-normal` – heading and body line heights
+- `--measure` – maximum line length for readable text blocks
+
 ## License
 
 `@lapidist/website` is licensed under the MIT license. See LICENSE for the full text.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,25 +2,20 @@ import type { Metadata, Viewport } from "next";
 import { Lexend_Deca, Roboto_Mono } from "next/font/google";
 import "@/styles/tokens.scss";
 import "@/styles/globals.scss";
+import "@/styles/typography.scss";
 
-// Limit downloaded font weights to reduce font file size.
-// Only the normal (400) and semi-bold (600) weights are used across the
-// site, so we explicitly request those weights from Google Fonts. This
-// prevents the default variable font files from being included, trimming
-// several unnecessary woff2 files from the build and improving
-// Lighthouse performance scores.
+// Load variable fonts so optical size and slant can be controlled via
+// `font-variation-settings` in CSS.
 const header = Lexend_Deca({
     variable: "--font-header",
     subsets: ["latin"],
     display: "swap",
-    weight: ["400", "600"],
 });
 
 const body = Roboto_Mono({
     variable: "--font-body",
     subsets: ["latin"],
     display: "swap",
-    weight: ["400", "600"],
 });
 
 export const viewport: Viewport = {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -14,9 +14,11 @@ body {
     font-family: var(--font-body), sans-serif;
     background: var(--bg);
     color: var(--text);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
     font-variant-numeric: tabular-nums;
     font-feature-settings: "kern", "liga", "clig", "calt";
+    font-variation-settings: "opsz" var(--font-opsz),
+        "slnt" var(--font-slnt);
 }
 
 @supports (font-size: clamp(1rem, 1vw, 2rem)) {
@@ -38,16 +40,9 @@ svg {
     font-family: var(--font-header), sans-serif;
     text-wrap: balance;
     hyphens: auto;
-    margin-block: 0;
-}
-
-:where(p, ul, ol, dl) {
-    margin-block: 0;
-}
-
-:where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl)
-    + :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl) {
-    margin-block-start: var(--space-m);
+    line-height: var(--leading-tight);
+    font-variation-settings: "opsz" var(--font-opsz),
+        "slnt" var(--font-slnt);
 }
 
 a {
@@ -81,9 +76,6 @@ section {
     transform: translateY(0);
 }
 
-:where(h1, h2, h3) + p {
-    margin-block-start: var(--space-xs);
-}
 
 :target {
     outline: var(--focus-ring);

--- a/styles/tokens.scss
+++ b/styles/tokens.scss
@@ -69,6 +69,11 @@
     --step-1: clamp(1.25rem, 1.15rem + 0.6vw, 1.5rem);
     --step-2: clamp(1.5rem, 1.3rem + 1vw, 2rem);
     --step-3: clamp(2rem, 1.7rem + 1.5vw, 2.5rem);
+    --leading-tight: 1.2;
+    --leading-normal: 1.5;
+    --measure: 60ch;
+    --font-opsz: 14;
+    --font-slnt: 0;
 
     /* layout */
     --max-w-s: 40rem;

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -1,0 +1,20 @@
+:where(h1, h2, h3, h4, h5, h6) {
+    margin-block: 0;
+    line-height: var(--leading-tight);
+    max-inline-size: var(--measure);
+}
+
+:where(p, ul, ol, dl) {
+    margin-block: 0;
+    line-height: var(--leading-normal);
+    max-inline-size: var(--measure);
+}
+
+:where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl)
+    + :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl) {
+    margin-block-start: var(--space-m);
+}
+
+:where(h1, h2, h3) + p {
+    margin-block-start: var(--space-xs);
+}


### PR DESCRIPTION
## Summary
- load variable fonts and enable optical sizing and slant via `font-variation-settings`
- limit line length with `max-inline-size` and adjust vertical rhythm
- document new typography tokens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0e3dad848328be22c35bbae5d149