### PR TITLE
feat: add motion helpers

### DIFF
--- a/MOTION.md
+++ b/MOTION.md
@@ -1,0 +1,16 @@
+# Motion
+
+This site uses motion tokens defined in `styles/tokens.scss` to keep animation consistent:
+
+- `--ease-standard` and `--ease-emph` provide easing curves.
+- `--dur-1`, `--dur-2`, and `--dur-3` define standard durations.
+
+## Entrance animations
+
+Helpers for entrance transitions live in `styles/motion.scss` and `lib/motion.ts`.
+
+1. Apply the `@include fade-slide-up;` mixin to the element's class.
+2. Use the `useInView` hook to receive an element ref and add an `isVisible` class when it enters the viewport.
+3. Animations are wrapped in a `prefers-reduced-motion: no-preference` media query; users who prefer reduced motion see content without transitions.
+
+These utilities keep motion subtle and respectful while providing a polished entrance effect.

--- a/components/Stats/Stats.module.scss
+++ b/components/Stats/Stats.module.scss
@@ -1,3 +1,14 @@
+@use "../../styles/motion" as *;
+
+.root {
+    @include fade-slide-up;
+
+    &.isVisible {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .stats {
     display: flex;
     flex-wrap: wrap;

--- a/components/Stats/Stats.tsx
+++ b/components/Stats/Stats.tsx
@@ -1,11 +1,17 @@
+"use client";
+
 import Container from "@/components/Container/Container";
 import Stat from "@/components/Stat/Stat";
 import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
+import { useInView } from "@/lib/motion";
 import styles from "./Stats.module.scss";
 
 export default function Stats() {
+    const ref = useInView<HTMLElement>();
     return (
         <section
+            ref={ref}
+            className={styles.root}
             role="region"
             aria-labelledby="stats-heading"
             style={{ contentVisibility: "auto" }}

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+export function useInView<T extends HTMLElement>() {
+    const ref = useRef<T>(null);
+
+    useEffect(() => {
+        const node = ref.current;
+        if (!node) return;
+
+        const prefersReduced = window
+            .matchMedia("(prefers-reduced-motion: reduce)")
+            .matches;
+
+        if (prefersReduced) {
+            node.classList.add("isVisible");
+            return;
+        }
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add("isVisible");
+                    observer.disconnect();
+                }
+            });
+        });
+
+        observer.observe(node);
+        return () => {
+            observer.disconnect();
+        };
+    }, []);
+
+    return ref;
+}

--- a/styles/motion.scss
+++ b/styles/motion.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable no-invalid-position-declaration */
+@mixin fade-slide-up {
+    opacity: 0;
+    transform: translateY(var(--space-m));
+
+    @media (prefers-reduced-motion: no-preference) {
+        transition-property: opacity, transform;
+        transition-duration: var(--dur-3);
+        transition-timing-function: var(--ease-standard);
+    }
+}
+/* stylelint-enable no-invalid-position-declaration */


### PR DESCRIPTION
## Summary
- document motion tokens and entrance animation usage
- add fade/slide SCSS mixin and intersection hook
- animate Stats section on view with reduced-motion safeguards

## Testing
- `npm run lint`
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b0ed828008328a0cc7ca667023b76