### PR TITLE
Extend typography scale for hero and contact banner

### DIFF
--- a/components/Contact/Contact.module.scss
+++ b/components/Contact/Contact.module.scss
@@ -1,6 +1,17 @@
 @use "../../styles/mixins" as *;
 
 @layer components {
+    .heading {
+        text-align: center;
+        font-size: var(--step-3);
+    }
+
+    @container (min-width:40rem) {
+        .heading {
+            font-size: var(--step-4);
+        }
+    }
+
     .ctaGroup {
         @include cta-group;
     }

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -11,7 +11,9 @@ export default function Contact() {
             style={{ contentVisibility: "auto" }}
         >
             <Container>
-                <h2 id="contact-heading">Ready to ship?</h2>
+                <h2 id="contact-heading" className={styles.heading}>
+                    Ready to ship?
+                </h2>
                 <div className={styles.ctaGroup}>
                     <Button href="mailto:hello@lapidist.net">
                         Book a 20-min discovery call

--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -9,12 +9,14 @@
         max-inline-size: 25ch;
         text-wrap: balance;
         hyphens: auto;
+        font-size: var(--step-4);
     }
 
     .heroIntro {
         max-inline-size: 45ch;
         text-wrap: balance;
         hyphens: auto;
+        font-size: var(--step-2);
     }
 
     .ctaGroup {
@@ -32,5 +34,15 @@
         font-size: var(--step-negative-1);
         max-inline-size: 14ch;
         text-align: center;
+    }
+
+    @container (min-width:50rem) {
+        .heroTitle {
+            font-size: var(--step-5);
+        }
+
+        .heroIntro {
+            font-size: var(--step-3);
+        }
     }
 }

--- a/styles/tokens.scss
+++ b/styles/tokens.scss
@@ -69,6 +69,8 @@
     --step-1: clamp(1.25rem, 1.15rem + 0.6vw, 1.5rem);
     --step-2: clamp(1.5rem, 1.3rem + 1vw, 2rem);
     --step-3: clamp(2rem, 1.7rem + 1.5vw, 2.5rem);
+    --step-4: clamp(2.5rem, 2.1rem + 2vw, 3rem);
+    --step-5: clamp(3rem, 2.5rem + 2.5vw, 3.5rem);
     --leading-tight: 1.2;
     --leading-normal: 1.5;
     --measure: 60ch;


### PR DESCRIPTION
## Summary
- add `--step-4` and `--step-5` font size tokens
- apply larger type scale to hero and contact banner headings
- scale hero and banner typography across container breakpoints

## Testing
- `npm run lint`
- `npm test`
- `npm run format` *(fails: Code style issues found in 11 files)*

------
https://chatgpt.com/codex/tasks/task_e_689b1561d1d88328b130d2a2d5d57b6f