### PR TITLE
feat: add animated hero background

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -2,6 +2,8 @@
 
 @layer components {
     .hero {
+        position: relative;
+        overflow: hidden;
         text-align: center;
     }
 
@@ -10,6 +12,13 @@
         text-wrap: balance;
         hyphens: auto;
         font-size: var(--step-4);
+    }
+
+    .background {
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        content-visibility: auto;
     }
 
     .heroIntro {

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,6 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
 import Button from "@/components/Button/Button";
 import Container from "@/components/Container/Container";
 import styles from "./Hero.module.scss";
+
+const HeroBackground = dynamic(
+    () => import("@/components/HeroBackground/HeroBackground"),
+    {
+        ssr: false,
+        loading: () => (
+            <picture>
+                <source srcSet="/hero-bg-dark.svg" media="(prefers-color-scheme: dark)" />
+                <img src="/hero-bg-light.svg" alt="" aria-hidden="true" />
+            </picture>
+        ),
+    }
+);
 
 export default function Hero() {
     return (
@@ -9,6 +25,9 @@ export default function Hero() {
             role="region"
             aria-labelledby="hero-heading"
         >
+            <div className={styles.background}>
+                <HeroBackground />
+            </div>
             <Container size="l">
                 <div className={styles.ctaGroup}>
                     <h1 id="hero-heading" className={styles.heroTitle}>

--- a/components/HeroBackground/HeroBackground.module.scss
+++ b/components/HeroBackground/HeroBackground.module.scss
@@ -1,0 +1,8 @@
+@layer components {
+    .canvas,
+    .image {
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/components/HeroBackground/HeroBackground.tsx
+++ b/components/HeroBackground/HeroBackground.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+import {
+    Color,
+    Mesh,
+    PerspectiveCamera,
+    PlaneGeometry,
+    Scene,
+    ShaderMaterial,
+    WebGLRenderer,
+} from "three";
+import styles from "./HeroBackground.module.scss";
+
+export default function HeroBackground() {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [shouldAnimate, setShouldAnimate] = useState(false);
+
+    useEffect(() => {
+        const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+        if (!media.matches) {
+            setShouldAnimate(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!shouldAnimate) return;
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        const renderer = new WebGLRenderer({ canvas, antialias: true });
+        const scene = new Scene();
+        const camera = new PerspectiveCamera(
+            45,
+            canvas.clientWidth / canvas.clientHeight,
+            0.1,
+            100
+        );
+        camera.position.z = 1;
+
+        const geometry = new PlaneGeometry(2, 2);
+
+        const style = getComputedStyle(document.documentElement);
+        const color1 = new Color(style.getPropertyValue("--surface").trim());
+        const color2 = new Color(style.getPropertyValue("--bg").trim());
+
+        const material = new ShaderMaterial({
+            uniforms: {
+                uTime: { value: 0 },
+                uColor1: { value: color1 },
+                uColor2: { value: color2 },
+            },
+            vertexShader: `
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: `
+                uniform float uTime;
+                uniform vec3 uColor1;
+                uniform vec3 uColor2;
+                varying vec2 vUv;
+                void main() {
+                    float wave = sin((vUv.x + uTime * 0.05) * 6.2831) * 0.02;
+                    vec3 color = mix(uColor1, uColor2, vUv.y + wave);
+                    gl_FragColor = vec4(color, 1.0);
+                }
+            `,
+        });
+
+        const mesh = new Mesh(geometry, material);
+        scene.add(mesh);
+
+        const handleResize = () => {
+            const { clientWidth, clientHeight } = canvas;
+            renderer.setSize(clientWidth, clientHeight, false);
+            camera.aspect = clientWidth / clientHeight;
+            camera.updateProjectionMatrix();
+        };
+        handleResize();
+        window.addEventListener("resize", handleResize);
+
+        let frameId: number;
+        const animate = (time: number) => {
+            material.uniforms.uTime.value = time / 1000;
+            renderer.render(scene, camera);
+            frameId = requestAnimationFrame(animate);
+        };
+        frameId = requestAnimationFrame(animate);
+
+        return () => {
+            cancelAnimationFrame(frameId);
+            window.removeEventListener("resize", handleResize);
+            renderer.dispose();
+            geometry.dispose();
+            material.dispose();
+        };
+    }, [shouldAnimate]);
+
+    if (!shouldAnimate) {
+        return (
+            <picture>
+                <source srcSet="/hero-bg-dark.svg" media="(prefers-color-scheme: dark)" />
+                <img
+                    className={styles.image}
+                    src="/hero-bg-light.svg"
+                    alt=""
+                    aria-hidden="true"
+                />
+            </picture>
+        );
+    }
+
+    return <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
                 "next": "15.4.6",
                 "prettier": "3.6.2",
                 "react": "19.1.1",
-                "react-dom": "19.1.1"
+                "react-dom": "19.1.1",
+                "three": "^0.179.1"
             },
             "devDependencies": {
                 "@axe-core/playwright": "4.10.2",
@@ -27,6 +28,7 @@
                 "@types/node": "24.2.1",
                 "@types/react": "19.1.10",
                 "@types/react-dom": "19.1.7",
+                "@types/three": "^0.179.0",
                 "eslint": "9.33.0",
                 "eslint-config-next": "15.4.6",
                 "eslint-import-resolver-typescript": "^4.4.4",
@@ -1992,6 +1994,13 @@
             "peerDependencies": {
                 "postcss-selector-parser": "^7.0.0"
             }
+        },
+        "node_modules/@dimforge/rapier3d-compat": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+            "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/@dual-bundle/import-meta-resolve": {
             "version": "4.1.0",
@@ -6290,6 +6299,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@tweenjs/tween.js": {
+            "version": "23.1.3",
+            "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+            "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -6528,6 +6544,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/stats.js": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+            "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/tedious": {
             "version": "4.0.14",
             "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
@@ -6537,6 +6560,29 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/three": {
+            "version": "0.179.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.179.0.tgz",
+            "integrity": "sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@dimforge/rapier3d-compat": "~0.12.0",
+                "@tweenjs/tween.js": "~23.1.3",
+                "@types/stats.js": "*",
+                "@types/webxr": "*",
+                "@webgpu/types": "*",
+                "fflate": "~0.8.2",
+                "meshoptimizer": "~0.22.0"
+            }
+        },
+        "node_modules/@types/webxr": {
+            "version": "0.5.22",
+            "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+            "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
@@ -7351,6 +7397,13 @@
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
             }
+        },
+        "node_modules/@webgpu/types": {
+            "version": "0.1.64",
+            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+            "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
@@ -11484,6 +11537,13 @@
                 "pend": "~1.2.0"
             }
         },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/figures": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -14226,6 +14286,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/meshoptimizer": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+            "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/metaviewport-parser": {
             "version": "0.3.0",
@@ -18330,6 +18397,12 @@
             "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
             "integrity": "sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/three": {
+            "version": "0.179.1",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+            "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
             "license": "MIT"
         },
         "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "next": "15.4.6",
         "prettier": "3.6.2",
         "react": "19.1.1",
-        "react-dom": "19.1.1"
+        "react-dom": "19.1.1",
+        "three": "^0.179.1"
     },
     "devDependencies": {
         "@axe-core/playwright": "4.10.2",
@@ -53,6 +54,7 @@
         "@types/node": "24.2.1",
         "@types/react": "19.1.10",
         "@types/react-dom": "19.1.7",
+        "@types/three": "^0.179.0",
         "eslint": "9.33.0",
         "eslint-config-next": "15.4.6",
         "eslint-import-resolver-typescript": "^4.4.4",

--- a/public/hero-bg-dark.svg
+++ b/public/hero-bg-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a1a1a"/>
+      <stop offset="100%" stop-color="#222222"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g)"/>
+</svg>

--- a/public/hero-bg-light.svg
+++ b/public/hero-bg-light.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f5f5f5"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g)"/>
+</svg>


### PR DESCRIPTION
## Summary
- add three.js-based `HeroBackground` with shader animation and reduced-motion fallback
- lazy-load `HeroBackground` in `Hero` with content-visibility and static SVG placeholders
- include light and dark SVG fallbacks and update styles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689b1d72fa6c832887005b8164915792