### PR TITLE
fix: convert CSS color variables for hero background

### DIFF
--- a/components/HeroBackground/HeroBackground.tsx
+++ b/components/HeroBackground/HeroBackground.tsx
@@ -39,8 +39,17 @@ export default function HeroBackground() {
         const geometry = new PlaneGeometry(2, 2);
 
         const style = getComputedStyle(document.documentElement);
-        const color1 = new Color(style.getPropertyValue("--surface").trim());
-        const color2 = new Color(style.getPropertyValue("--bg").trim());
+        const parseColor = (variable: string) => {
+            const value = style.getPropertyValue(variable).trim();
+            const element = document.createElement("div");
+            element.style.color = value;
+            document.body.appendChild(element);
+            const rgb = getComputedStyle(element).color;
+            element.remove();
+            return rgb;
+        };
+        const color1 = new Color(parseColor("--surface"));
+        const color2 = new Color(parseColor("--bg"));
 
         const material = new ShaderMaterial({
             uniforms: {


### PR DESCRIPTION
## Summary
- parse CSS custom property values to rgb for Three.js hero background

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b267f7d788328b80982338ea85a52