### PR TITLE
refactor: remove dynamic imports

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,13 @@
-import dynamic from "next/dynamic";
 import Footer from "@/components/Footer/Footer";
 import Hero from "@/components/Hero/Hero";
+import Stats from "@/components/Stats/Stats";
+import ProblemToSolution from "@/components/ProblemToSolution/ProblemToSolution";
+import Services from "@/components/Services/Services";
+import Approach from "@/components/Approach/Approach";
+import Pledge from "@/components/Pledge/Pledge";
+import CaseExample from "@/components/CaseExample/CaseExample";
+import Contact from "@/components/Contact/Contact";
 import { buildStructuredData } from "./structuredData";
-
-const Stats = dynamic(() => import("@/components/Stats/Stats"));
-const ProblemToSolution = dynamic(
-    () => import("@/components/ProblemToSolution/ProblemToSolution"),
-);
-const Services = dynamic(() => import("@/components/Services/Services"));
-const Approach = dynamic(() => import("@/components/Approach/Approach"));
-const Pledge = dynamic(() => import("@/components/Pledge/Pledge"));
-const CaseExample = dynamic(
-    () => import("@/components/CaseExample/CaseExample"),
-);
-const Contact = dynamic(() => import("@/components/Contact/Contact"));
 
 export default function Page() {
     const structuredData = buildStructuredData();

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,22 +1,9 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import Button from "@/components/Button/Button";
 import Container from "@/components/Container/Container";
+import HeroBackground from "@/components/HeroBackground/HeroBackground";
 import styles from "./Hero.module.scss";
-
-const HeroBackground = dynamic(
-    () => import("@/components/HeroBackground/HeroBackground"),
-    {
-        ssr: false,
-        loading: () => (
-            <picture>
-                <source srcSet="/hero-bg-dark.svg" media="(prefers-color-scheme: dark)" />
-                <img src="/hero-bg-light.svg" alt="" aria-hidden="true" />
-            </picture>
-        ),
-    }
-);
 
 export default function Hero() {
     return (


### PR DESCRIPTION
## Summary
- replace `next/dynamic` usage with static imports on the homepage and hero component

## Testing
- `npm run lint`
- `npm run format` (reported code style issues in 13 files)
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b263659fc8328a96d660172a0fcad