### PR TITLE
Improve footer spacing and typography

### DIFF
--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -1,4 +1,12 @@
 @layer components {
+    .footer {
+        padding-block: var(--space-xl);
+        border-block-start: 1px solid var(--border);
+        font-size: var(--step-negative-1);
+        text-align: center;
+        color: var(--text-subtle);
+    }
+
     .footerNav,
     .social {
         list-style: none;
@@ -6,10 +14,16 @@
         display: flex;
         gap: var(--space-s);
         align-items: center;
+        justify-content: center;
     }
 
     .footerNav {
         flex-wrap: wrap;
+        margin-block-end: var(--space-m);
+    }
+
+    .footer p {
+        margin-block-start: var(--space-s);
     }
 
     .footerNav a,
@@ -21,5 +35,6 @@
         min-inline-size: 44px;
         text-decoration: none;
         padding: var(--space-xs) var(--space-s);
+        color: var(--text);
     }
 }

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -4,7 +4,7 @@ import styles from "./Footer.module.scss";
 
 export default function Footer() {
     return (
-        <footer>
+        <footer className={styles.footer}>
             <Container>
                 <nav aria-label="Footer">
                     <ul className={styles.footerNav}>


### PR DESCRIPTION
## Summary
- refine footer layout with centered navigation and subtle text styling
- add padding and borders for clearer footer separation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b495479448328a67cfa31ebe37cbd