### PR TITLE
refactor: extract reusable Section component

### DIFF
--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -1,34 +1,28 @@
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import styles from "./Approach.module.scss";
 
 export default function Approach() {
     return (
-        <section
-            role="region"
-            aria-labelledby="approach-heading"
-            style={{ contentVisibility: "auto" }}
-        >
-            <Container>
-                <h2 id="approach-heading">My approach</h2>
-                <ol className={styles.steps}>
-                    <li>
-                        <strong>Audit</strong> &rarr; analyse the current UI and
-                        spot opportunities.
-                    </li>
-                    <li>
-                        <strong>Prototype</strong> &rarr; early improvements and
-                        gather feedback.
-                    </li>
-                    <li>
-                        <strong>Rollout</strong> &rarr; launch, measure, and
-                        refine.
-                    </li>
-                    <li>
-                        <strong>Review</strong> &rarr; continuous improvements
-                        and review.
-                    </li>
-                </ol>
-            </Container>
-        </section>
+        <Section labelledBy="approach-heading">
+            <h2 id="approach-heading">My approach</h2>
+            <ol className={styles.steps}>
+                <li>
+                    <strong>Audit</strong> &rarr; analyse the current UI and
+                    spot opportunities.
+                </li>
+                <li>
+                    <strong>Prototype</strong> &rarr; early improvements and
+                    gather feedback.
+                </li>
+                <li>
+                    <strong>Rollout</strong> &rarr; launch, measure, and
+                    refine.
+                </li>
+                <li>
+                    <strong>Review</strong> &rarr; continuous improvements and
+                    review.
+                </li>
+            </ol>
+        </Section>
     );
 }

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,28 +1,21 @@
 import Button from "@/components/Button/Button";
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import styles from "./Contact.module.scss";
 
 export default function Contact() {
     return (
-        <section
-            id="contact"
-            role="region"
-            aria-labelledby="contact-heading"
-            style={{ contentVisibility: "auto" }}
-        >
-            <Container>
-                <h2 id="contact-heading" className={styles.heading}>
-                    Ready to ship?
-                </h2>
-                <div className={styles.ctaGroup}>
-                    <Button href="mailto:hello@lapidist.net">
-                        Book a 20-min discovery call
-                    </Button>
-                    <Button href="/brett-dorrans-cv.pdf" variant="secondary">
-                        Download capabilities deck
-                    </Button>
-                </div>
-            </Container>
-        </section>
+        <Section id="contact" labelledBy="contact-heading">
+            <h2 id="contact-heading" className={styles.heading}>
+                Ready to ship?
+            </h2>
+            <div className={styles.ctaGroup}>
+                <Button href="mailto:hello@lapidist.net">
+                    Book a 20-min discovery call
+                </Button>
+                <Button href="/brett-dorrans-cv.pdf" variant="secondary">
+                    Download capabilities deck
+                </Button>
+            </div>
+        </Section>
     );
 }

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,43 +1,42 @@
 import Button from "@/components/Button/Button";
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import styles from "./Hero.module.scss";
 
 export default function Hero() {
     return (
-        <section
+        <Section
             className={styles.hero}
-            role="region"
-            aria-labelledby="hero-heading"
+            labelledBy="hero-heading"
+            containerSize="l"
+            contentVisibility={false}
         >
-            <Container size="l">
-                <div className={styles.ctaGroup}>
-                    <h1 id="hero-heading" className={styles.heroTitle}>
-                        Ship design systems teams trust.
-                    </h1>
-                    <p className={styles.heroIntro}>
-                        I help product orgs ship consistent UI faster &ndash;
-                        governance, performance, and accessibility baked in.
-                    </p>
+            <div className={styles.ctaGroup}>
+                <h1 id="hero-heading" className={styles.heroTitle}>
+                    Ship design systems teams trust.
+                </h1>
+                <p className={styles.heroIntro}>
+                    I help product orgs ship consistent UI faster &ndash;
+                    governance, performance, and accessibility baked in.
+                </p>
+            </div>
+            <div className={styles.ctaGroup}>
+                <div className={styles.cta}>
+                    <Button href="#contact" size="lg">
+                        Book a 20-min discovery call
+                    </Button>
+                    <p className={styles.note}>Let&apos;s chat.</p>
                 </div>
-                <div className={styles.ctaGroup}>
-                    <div className={styles.cta}>
-                        <Button href="#contact" size="lg">
-                            Book a 20-min discovery call
-                        </Button>
-                        <p className={styles.note}>Let&apos;s chat.</p>
-                    </div>
-                    <div className={styles.cta}>
-                        <Button
-                            href="/brett-dorrans-cv.pdf"
-                            variant="secondary"
-                            size="lg"
-                        >
-                            Download capabilities deck
-                        </Button>
-                        <p className={styles.note}>No email gate.</p>
-                    </div>
+                <div className={styles.cta}>
+                    <Button
+                        href="/brett-dorrans-cv.pdf"
+                        variant="secondary"
+                        size="lg"
+                    >
+                        Download capabilities deck
+                    </Button>
+                    <p className={styles.note}>No email gate.</p>
                 </div>
-            </Container>
-        </section>
+            </div>
+        </Section>
     );
 }

--- a/components/Pledge/Pledge.tsx
+++ b/components/Pledge/Pledge.tsx
@@ -1,44 +1,36 @@
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
 import styles from "./Pledge.module.scss";
 
 export default function Pledge() {
     return (
-        <section
-            role="region"
-            aria-labelledby="pledge-heading"
-            style={{ contentVisibility: "auto" }}
-        >
-            <Container>
-                <h2 id="pledge-heading">
-                    <VisuallyHidden>
-                        Accessibility &amp; Performance pledge
-                    </VisuallyHidden>
-                </h2>
-                <details>
-                    <summary>
-                        View my Accessibility &amp; Performance pledge
-                    </summary>
-                    <dl className={styles.checklist}>
-                        <div>
-                            <dt>Keyboard-first:</dt>
-                            <dd>Every control works without a mouse.</dd>
-                        </div>
-                        <div>
-                            <dt>Contrast:</dt>
-                            <dd>Minimum 4.5:1 text contrast.</dd>
-                        </div>
-                        <div>
-                            <dt>Fast paint:</dt>
-                            <dd>95th percentile route paint &lt;1.2s.</dd>
-                        </div>
-                        <div>
-                            <dt>Motion aware:</dt>
-                            <dd>Animations off when you prefer less.</dd>
-                        </div>
-                    </dl>
-                </details>
-            </Container>
-        </section>
+        <Section labelledBy="pledge-heading">
+            <h2 id="pledge-heading">
+                <VisuallyHidden>
+                    Accessibility &amp; Performance pledge
+                </VisuallyHidden>
+            </h2>
+            <details>
+                <summary>View my Accessibility &amp; Performance pledge</summary>
+                <dl className={styles.checklist}>
+                    <div>
+                        <dt>Keyboard-first:</dt>
+                        <dd>Every control works without a mouse.</dd>
+                    </div>
+                    <div>
+                        <dt>Contrast:</dt>
+                        <dd>Minimum 4.5:1 text contrast.</dd>
+                    </div>
+                    <div>
+                        <dt>Fast paint:</dt>
+                        <dd>95th percentile route paint &lt;1.2s.</dd>
+                    </div>
+                    <div>
+                        <dt>Motion aware:</dt>
+                        <dd>Animations off when you prefer less.</dd>
+                    </div>
+                </dl>
+            </details>
+        </Section>
     );
 }

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode, CSSProperties } from "react";
+import Container from "@/components/Container/Container";
+
+interface Props {
+    id?: string;
+    labelledBy: string;
+    className?: string;
+    containerSize?: "s" | "m" | "l";
+    style?: CSSProperties;
+    contentVisibility?: boolean;
+    children: ReactNode;
+}
+
+export default function Section({
+    id,
+    labelledBy,
+    className,
+    containerSize,
+    style,
+    contentVisibility = true,
+    children,
+}: Props) {
+    const sectionStyle = contentVisibility
+        ? ({ contentVisibility: "auto", ...style } as CSSProperties)
+        : style;
+
+    return (
+        <section
+            id={id}
+            role="region"
+            aria-labelledby={labelledBy}
+            className={className}
+            style={sectionStyle}
+        >
+            <Container size={containerSize}>{children}</Container>
+        </section>
+    );
+}

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -1,50 +1,41 @@
 import Card from "@/components/Card/Card";
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import styles from "./Services.module.scss";
 
 export default function Services() {
     return (
-        <section
-            id="services"
-            role="region"
-            aria-labelledby="services-heading"
-            style={{ contentVisibility: "auto" }}
-        >
-            <Container>
-                <h2 id="services-heading">Signature services</h2>
-                <div className={styles.cards}>
-                    <Card title="Design System Bootstrap" highlight>
-                        <p>Launch a production-ready design system in weeks.</p>
-                        <p>Give your product team the momentum it needs.</p>
-                    </Card>
-                    <Card title="System Audit & Roadmap">
-                        <p>
-                            Turn your existing assets into a clear system
-                            strategy.
-                        </p>
-                        <p>
-                            Receive a practical roadmap to grow what you have.
-                        </p>
-                    </Card>
-                    <Card title="Hands-on Build">
-                        <p>
-                            Ship reliable system foundations without diverting
-                            your team.
-                        </p>
-                        <p>Gain patterns and processes that last.</p>
-                    </Card>
-                    <Card title="Advisory & Team Uplift">
-                        <p>
-                            Grow your team&apos;s capabilities with ongoing
-                            guidance.
-                        </p>
-                        <p>
-                            Raise quality through tailored standards, coaching
-                            and reviews.
-                        </p>
-                    </Card>
-                </div>
-            </Container>
-        </section>
+        <Section id="services" labelledBy="services-heading">
+            <h2 id="services-heading">Signature services</h2>
+            <div className={styles.cards}>
+                <Card title="Design System Bootstrap" highlight>
+                    <p>Launch a production-ready design system in weeks.</p>
+                    <p>Give your product team the momentum it needs.</p>
+                </Card>
+                <Card title="System Audit & Roadmap">
+                    <p>
+                        Turn your existing assets into a clear system strategy.
+                    </p>
+                    <p>
+                        Receive a practical roadmap to grow what you have.
+                    </p>
+                </Card>
+                <Card title="Hands-on Build">
+                    <p>
+                        Ship reliable system foundations without diverting your
+                        team.
+                    </p>
+                    <p>Gain patterns and processes that last.</p>
+                </Card>
+                <Card title="Advisory & Team Uplift">
+                    <p>
+                        Grow your team&apos;s capabilities with ongoing guidance.
+                    </p>
+                    <p>
+                        Raise quality through tailored standards, coaching and
+                        reviews.
+                    </p>
+                </Card>
+            </div>
+        </Section>
     );
 }

--- a/components/WhatIBring/WhatIBring.tsx
+++ b/components/WhatIBring/WhatIBring.tsx
@@ -1,35 +1,27 @@
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import styles from "./WhatIBring.module.scss";
 
 export default function WhatIBring() {
     return (
-        <section
-            role="region"
-            aria-labelledby="problem-to-solution-heading"
-            style={{ contentVisibility: "auto" }}
-        >
-            <Container>
-                <h2 id="problem-to-solution-heading">
-                    What I bring to the table
-                </h2>
-                <p>I bridge the gap between product, design and engineering.</p>
-                <p>
-                    My work has shaped everything from small internal tools to
-                    enterprise level design systems used across the globe.
-                </p>
-                <p>
-                    With the right tools, smart processes, and well structured
-                    teams, I make sure your UI systems do more than scale.
-                </p>
-                <ul className={styles.steps}>
-                    <li>Build teams and cross-functional culture.</li>
-                    <li>Tame design drift with scalable tokens.</li>
-                    <li>Cut PR nitpicks via shared components.</li>
-                    <li>Speed handoff through automated docs.</li>
-                    <li>Bake in accessibility from the start.</li>
-                    <li>Scale complex UI products quickly.</li>
-                </ul>
-            </Container>
-        </section>
+        <Section labelledBy="problem-to-solution-heading">
+            <h2 id="problem-to-solution-heading">What I bring to the table</h2>
+            <p>I bridge the gap between product, design and engineering.</p>
+            <p>
+                My work has shaped everything from small internal tools to
+                enterprise level design systems used across the globe.
+            </p>
+            <p>
+                With the right tools, smart processes, and well structured
+                teams, I make sure your UI systems do more than scale.
+            </p>
+            <ul className={styles.steps}>
+                <li>Build teams and cross-functional culture.</li>
+                <li>Tame design drift with scalable tokens.</li>
+                <li>Cut PR nitpicks via shared components.</li>
+                <li>Speed handoff through automated docs.</li>
+                <li>Bake in accessibility from the start.</li>
+                <li>Scale complex UI products quickly.</li>
+            </ul>
+        </Section>
     );
 }


### PR DESCRIPTION
## Summary
- add a generic Section wrapper that handles region markup and container layout
- replace repeated section+Container patterns across Approach, Services, WhatIBring, Pledge, Contact and Hero components

## Testing
- `npm run lint`
- `npm test` *(fails: Process from config.webServer exited early)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b4db683148328a0d7410e33c5510a