### PR TITLE
feat: add global header with theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Lexend_Deca, Roboto_Mono } from "next/font/google";
 import "@/styles/tokens.scss";
 import "@/styles/globals.scss";
 import "@/styles/typography.scss";
+import Header from "@/components/Header/Header";
 
 // Load variable fonts so optical size and slant can be controlled via
 // `font-variation-settings` in CSS.
@@ -100,6 +101,7 @@ export default function RootLayout({
                 <a href="#main" className="skip-link">
                     Skip to content
                 </a>
+                <Header />
                 <main id="main">{children}</main>
             </body>
         </html>

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -1,0 +1,55 @@
+@layer components {
+    .header {
+        position: sticky;
+        inset-block-start: 0;
+        z-index: var(--z-2);
+        background: var(--bg);
+        border-block-end: 1px solid var(--border);
+    }
+
+    .inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-block: var(--space-s);
+    }
+
+    .logo {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-xs);
+        text-decoration: none;
+        color: var(--text);
+    }
+
+    .nav {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        gap: var(--space-s);
+    }
+
+    .nav a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-block-size: 44px;
+        min-inline-size: 44px;
+        padding: var(--space-xs) var(--space-s);
+        text-decoration: none;
+        color: var(--text);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .nav a:hover,
+        .logo:hover {
+            background: var(--surface-hover);
+        }
+
+        .nav a:active,
+        .logo:active {
+            background: var(--surface-active);
+        }
+    }
+}

--- a/components/Header/Header.stories.tsx
+++ b/components/Header/Header.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import Header from "./Header";
+
+const meta = {
+    title: "Components/Header",
+    component: Header,
+} satisfies Meta<typeof Header>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import Container from "@/components/Container/Container";
+import ThemeToggle from "@/components/ThemeToggle/ThemeToggle";
+import styles from "./Header.module.scss";
+
+export default function Header() {
+    return (
+        <header className={styles.header}>
+            <Container className={styles.inner} cq="page">
+                <Link href="/" className={styles.logo}>
+                    <svg
+                        width="32"
+                        height="32"
+                        viewBox="0 0 32 32"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <rect
+                            width="32"
+                            height="32"
+                            rx="4"
+                            fill="currentColor"
+                        />
+                    </svg>
+                    <span className={styles.logoText}>Brett Dorrans</span>
+                </Link>
+                <nav aria-label="Main">
+                    <ul className={styles.nav}>
+                        <li>
+                            <Link href="/">Home</Link>
+                        </li>
+                        <li>
+                            <a href="#services">Services</a>
+                        </li>
+                        <li>
+                            <a href="#contact">Contact</a>
+                        </li>
+                    </ul>
+                </nav>
+                <ThemeToggle />
+            </Container>
+        </header>
+    );
+}

--- a/components/ThemeToggle/ThemeToggle.module.scss
+++ b/components/ThemeToggle/ThemeToggle.module.scss
@@ -1,0 +1,25 @@
+@layer components {
+    .toggle {
+        background: none;
+        border: none;
+        color: inherit;
+        cursor: pointer;
+        padding: var(--space-xs);
+        border-radius: var(--radius-s);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-block-size: 44px;
+        min-inline-size: 44px;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .toggle:hover {
+            background: var(--surface-hover);
+        }
+
+        .toggle:active {
+            background: var(--surface-active);
+        }
+    }
+}

--- a/components/ThemeToggle/ThemeToggle.tsx
+++ b/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
+import styles from "./ThemeToggle.module.scss";
+
+export default function ThemeToggle() {
+    type Theme = "light" | "dark";
+    const [theme, setTheme] = useState<Theme>("light");
+
+    useEffect(() => {
+        const stored = window.localStorage.getItem("theme") as Theme | null;
+        const mq = window.matchMedia("(prefers-color-scheme: dark)");
+        const initial = stored ?? (mq.matches ? "dark" : "light");
+        document.documentElement.dataset.theme = initial;
+        document.documentElement.style.colorScheme = initial;
+        setTheme(initial);
+    }, []);
+
+    const toggle = () => {
+        const next = theme === "dark" ? "light" : "dark";
+        document.documentElement.dataset.theme = next;
+        document.documentElement.style.colorScheme = next;
+        window.localStorage.setItem("theme", next);
+        setTheme(next);
+    };
+
+    const isDark = theme === "dark";
+
+    return (
+        <button
+            type="button"
+            className={styles.toggle}
+            onClick={toggle}
+            aria-pressed={isDark}
+        >
+            {isDark ? (
+                <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                >
+                    <path
+                        d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z"
+                        fill="currentColor"
+                    />
+                </svg>
+            ) : (
+                <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                >
+                    <circle cx="12" cy="12" r="5" fill="currentColor" />
+                    <g stroke="currentColor" strokeWidth="2">
+                        <line x1="12" y1="1" x2="12" y2="3" />
+                        <line x1="12" y1="21" x2="12" y2="23" />
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                        <line x1="1" y1="12" x2="3" y2="12" />
+                        <line x1="21" y1="12" x2="23" y2="12" />
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                    </g>
+                </svg>
+            )}
+            <VisuallyHidden>
+                {isDark ? "Switch to light mode" : "Switch to dark mode"}
+            </VisuallyHidden>
+        </button>
+    );
+}

--- a/styles/tokens.scss
+++ b/styles/tokens.scss
@@ -135,7 +135,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme="light"]) {
         --bg: #090909;
         --surface: #1a1a1a;
         --surface-elevated: #222222;
@@ -171,7 +171,7 @@
     }
 
     @supports (color: oklch(0 0 0)) {
-        :root {
+        :root:not([data-theme="light"]) {
             --bg: oklch(12% 0 0deg);
             --surface: oklch(30% 0 0deg);
             --surface-elevated: oklch(35% 0 0deg);
@@ -208,6 +208,70 @@
     }
 }
 
+:root[data-theme="dark"] {
+    --bg: #090909;
+    --surface: #1a1a1a;
+    --surface-elevated: #222222;
+    --text: #f5f5f5;
+    --text-subtle: #b3b3b3;
+    --border: #333333;
+    --muted: #2a2a2a;
+    --surface-hover: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    --surface-active: color-mix(in srgb, var(--surface) 80%, var(--text) 20%);
+    --primary: #b0a3ff;
+    --primary-contrast: #000000;
+    --primary-hover: color-mix(
+        in srgb,
+        var(--primary) 90%,
+        var(--primary-contrast) 10%
+    );
+    --primary-active: color-mix(
+        in srgb,
+        var(--primary) 80%,
+        var(--primary-contrast) 20%
+    );
+    --success: #2fdd88;
+    --warning: #ffcb33;
+    --danger: #ff6b6b;
+}
+
+@supports (color: oklch(0 0 0)) {
+    :root[data-theme="dark"] {
+        --bg: oklch(12% 0 0deg);
+        --surface: oklch(30% 0 0deg);
+        --surface-elevated: oklch(35% 0 0deg);
+        --text: oklch(97% 0 0deg);
+        --text-subtle: oklch(75% 0 0deg);
+        --border: oklch(42% 0 0deg);
+        --muted: oklch(32% 0 0deg);
+        --surface-hover: color-mix(
+            in oklch,
+            var(--surface) 90%,
+            var(--text) 10%
+        );
+        --surface-active: color-mix(
+            in oklch,
+            var(--surface) 80%,
+            var(--text) 20%
+        );
+        --primary: oklch(75% 0.15 269deg);
+        --primary-contrast: oklch(0% 0 0deg);
+        --primary-hover: color-mix(
+            in oklch,
+            var(--primary) 90%,
+            var(--primary-contrast) 10%
+        );
+        --primary-active: color-mix(
+            in oklch,
+            var(--primary) 80%,
+            var(--primary-contrast) 20%
+        );
+        --success: oklch(82% 0.12 154deg);
+        --warning: oklch(88% 0.14 90deg);
+        --danger: oklch(72% 0.14 27deg);
+    }
+}
+
 /* High contrast mode for WCAG 2.2 AAA */
 @media (prefers-contrast: more) {
     :root {
@@ -224,7 +288,7 @@
     }
 
     @media (prefers-color-scheme: dark) {
-        :root {
+        :root:not([data-theme="light"]) {
             --bg: #000000;
             --surface: #000000;
             --primary: #ffff00;
@@ -236,6 +300,19 @@
             --primary-hover: #ffff66;
             --primary-active: #ffff00;
         }
+    }
+
+    :root[data-theme="dark"] {
+        --bg: #000000;
+        --surface: #000000;
+        --primary: #ffff00;
+        --primary-contrast: #000000;
+        --border: #ffffff;
+        --text-subtle: #ffffff;
+        --surface-hover: #1a1a1a;
+        --surface-active: #333333;
+        --primary-hover: #ffff66;
+        --primary-active: #ffff00;
     }
 }
 


### PR DESCRIPTION
## Summary
- add sticky Header with navigation and theme toggle
- support manual light/dark themes via data attributes
- wire Header into global layout

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: accessibility violations in smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b61ca131c8328bc34a1f96d5e9b4f