### PR TITLE
feat: add global header with theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Lexend_Deca, Roboto_Mono } from "next/font/google";
 import "@/styles/tokens.scss";
 import "@/styles/globals.scss";
 import "@/styles/typography.scss";
+import Header from "@/components/Header/Header";
 
 // Load variable fonts so optical size and slant can be controlled via
 // `font-variation-settings` in CSS.
@@ -97,9 +98,15 @@ export default function RootLayout({
                 <link rel="mask-icon" href="/mask-icon.svg" color="#6847ff" />
             </head>
             <body className={`${header.variable} ${body.variable}`}>
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: "try{const t=localStorage.getItem('theme');if(t){document.documentElement.setAttribute('data-theme',t);document.documentElement.style.colorScheme=t;}}catch(e){}",
+                    }}
+                />
                 <a href="#main" className="skip-link">
                     Skip to content
                 </a>
+                <Header />
                 <main id="main">{children}</main>
             </body>
         </html>

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -1,0 +1,66 @@
+@layer components {
+    .header {
+        position: sticky;
+        inset-block-start: 0;
+        z-index: var(--z-2);
+        border-block-end: 1px solid var(--border);
+        background: var(--surface);
+    }
+
+    .container {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-s);
+        padding-block: var(--space-s);
+    }
+
+    .logo {
+        display: inline-flex;
+        align-items: center;
+        color: var(--text);
+        text-decoration: none;
+    }
+
+    .nav {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        gap: var(--space-s);
+    }
+
+    .nav a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-block-size: 44px;
+        padding: var(--space-xs) var(--space-s);
+        text-decoration: none;
+        color: var(--text);
+    }
+
+    .themeToggle {
+        background: none;
+        border: 0;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-block-size: 44px;
+        min-inline-size: 44px;
+        color: var(--text);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .nav a:hover,
+        .themeToggle:hover {
+            background: var(--surface-hover);
+        }
+
+        .nav a:active,
+        .themeToggle:active {
+            background: var(--surface-active);
+        }
+    }
+}

--- a/components/Header/Header.stories.tsx
+++ b/components/Header/Header.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import Header from "./Header";
+
+const meta = {
+    title: "Components/Header",
+    component: Header,
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Container from "@/components/Container/Container";
+import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
+import styles from "./Header.module.scss";
+
+export default function Header() {
+    const [theme, setTheme] = useState<"light" | "dark" | undefined>();
+
+    useEffect(() => {
+        const stored = window.localStorage.getItem("theme");
+        if (stored === "light" || stored === "dark") {
+            document.documentElement.setAttribute("data-theme", stored);
+            document.documentElement.style.colorScheme = stored;
+            setTheme(stored);
+        }
+    }, []);
+
+    const toggleTheme = () => {
+        const next = theme === "dark" ? "light" : "dark";
+        document.documentElement.setAttribute("data-theme", next);
+        document.documentElement.style.colorScheme = next;
+        window.localStorage.setItem("theme", next);
+        setTheme(next);
+    };
+
+    return (
+        <header className={styles.header}>
+            <Container className={styles.container}>
+                <Link
+                    href="/"
+                    className={styles.logo}
+                    aria-label="Brett Dorrans"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 150 24"
+                        role="img"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <title>Brett Dorrans</title>
+                        <text
+                            x="0"
+                            y="17"
+                            fontSize="16"
+                            fontFamily="inherit"
+                            fill="currentColor"
+                        >
+                            Brett Dorrans
+                        </text>
+                    </svg>
+                </Link>
+                <nav aria-label="Main">
+                    <ul className={styles.nav}>
+                        <li>
+                            <Link href="/">Home</Link>
+                        </li>
+                        <li>
+                            <Link href="/articles">Articles</Link>
+                        </li>
+                        <li>
+                            <Link href="/#services">Services</Link>
+                        </li>
+                        <li>
+                            <Link href="/#contact">Contact</Link>
+                        </li>
+                    </ul>
+                </nav>
+                <button
+                    type="button"
+                    className={styles.themeToggle}
+                    onClick={toggleTheme}
+                    aria-pressed={theme === "dark"}
+                >
+                    <span aria-hidden="true">
+                        {theme === "dark" ? "🌙" : "☀️"}
+                    </span>
+                    <VisuallyHidden>Toggle dark mode</VisuallyHidden>
+                </button>
+            </Container>
+        </header>
+    );
+}

--- a/styles/tokens.scss
+++ b/styles/tokens.scss
@@ -92,6 +92,38 @@
     --focus-ring-offset: 2px;
 }
 
+:root[data-theme="light"] {
+    color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #090909;
+    --surface: #1a1a1a;
+    --surface-elevated: #222222;
+    --text: #f5f5f5;
+    --text-subtle: #b3b3b3;
+    --border: #333333;
+    --muted: #2a2a2a;
+    --surface-hover: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    --surface-active: color-mix(in srgb, var(--surface) 80%, var(--text) 20%);
+    --primary: #b0a3ff;
+    --primary-contrast: #000000;
+    --primary-hover: color-mix(
+        in srgb,
+        var(--primary) 90%,
+        var(--primary-contrast) 10%
+    );
+    --primary-active: color-mix(
+        in srgb,
+        var(--primary) 80%,
+        var(--primary-contrast) 20%
+    );
+    --success: #2fdd88;
+    --warning: #ffcb33;
+    --danger: #ff6b6b;
+}
+
 @supports (color: oklch(0 0 0)) {
     :root {
         --bg: oklch(100% 0 0deg);
@@ -132,10 +164,46 @@
         --shadow-3:
             0 4px 8px oklch(0% 0 0deg / 12%), 0 2px 4px oklch(0% 0 0deg / 8%);
     }
+
+    :root[data-theme="dark"] {
+        --bg: oklch(12% 0 0deg);
+        --surface: oklch(30% 0 0deg);
+        --surface-elevated: oklch(35% 0 0deg);
+        --text: oklch(97% 0 0deg);
+        --text-subtle: oklch(75% 0 0deg);
+        --border: oklch(42% 0 0deg);
+        --muted: oklch(32% 0 0deg);
+        --surface-hover: color-mix(
+            in oklch,
+            var(--surface) 90%,
+            var(--text) 10%
+        );
+        --surface-active: color-mix(
+            in oklch,
+            var(--surface) 80%,
+            var(--text) 20%
+        );
+        --primary: oklch(75% 0.15 269deg);
+        --primary-contrast: oklch(0% 0 0deg);
+        --primary-hover: color-mix(
+            in oklch,
+            var(--primary) 90%,
+            var(--primary-contrast) 10%
+        );
+        --primary-active: color-mix(
+            in oklch,
+            var(--primary) 80%,
+            var(--primary-contrast) 20%
+        );
+        --success: oklch(82% 0.12 154deg);
+        --warning: oklch(88% 0.14 90deg);
+        --danger: oklch(72% 0.14 27deg);
+    }
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme="light"]) {
+        color-scheme: dark;
         --bg: #090909;
         --surface: #1a1a1a;
         --surface-elevated: #222222;
@@ -171,7 +239,7 @@
     }
 
     @supports (color: oklch(0 0 0)) {
-        :root {
+        :root:not([data-theme="light"]) {
             --bg: oklch(12% 0 0deg);
             --surface: oklch(30% 0 0deg);
             --surface-elevated: oklch(35% 0 0deg);
@@ -223,8 +291,21 @@
         --primary-active: #0000cc;
     }
 
+    :root[data-theme="dark"] {
+        --bg: #000000;
+        --surface: #000000;
+        --primary: #ffff00;
+        --primary-contrast: #000000;
+        --border: #ffffff;
+        --text-subtle: #ffffff;
+        --surface-hover: #1a1a1a;
+        --surface-active: #333333;
+        --primary-hover: #ffff66;
+        --primary-active: #ffff00;
+    }
+
     @media (prefers-color-scheme: dark) {
-        :root {
+        :root:not([data-theme="light"]) {
             --bg: #000000;
             --surface: #000000;
             --primary: #ffff00;


### PR DESCRIPTION
## Summary
- add a reusable Header component with navigation, placeholder logo and theme toggle
- support manual light/dark themes via `data-theme` CSS variables
- inject header into root layout and initialise stored theme preference

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689b61d40b0483288a3d8190ae765d4e