### PR TITLE
feat: simplify section components

### DIFF
--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -3,8 +3,7 @@ import styles from "./Approach.module.scss";
 
 export default function Approach() {
     return (
-        <Section labelledBy="approach-heading">
-            <h2 id="approach-heading">My approach</h2>
+        <Section id="approach" heading="My approach">
             <ol className={styles.steps}>
                 <li>
                     <strong>Audit</strong> &rarr; analyse the current UI and
@@ -15,8 +14,7 @@ export default function Approach() {
                     gather feedback.
                 </li>
                 <li>
-                    <strong>Rollout</strong> &rarr; launch, measure, and
-                    refine.
+                    <strong>Rollout</strong> &rarr; launch, measure, and refine.
                 </li>
                 <li>
                     <strong>Review</strong> &rarr; continuous improvements and

--- a/components/CaseExample/CaseExample.tsx
+++ b/components/CaseExample/CaseExample.tsx
@@ -1,29 +1,21 @@
 import Card from "@/components/Card/Card";
-import Container from "@/components/Container/Container";
+import Section from "@/components/Section/Section";
 import styles from "./CaseExample.module.scss";
 
 export default function CaseExample() {
     return (
-        <section
-            role="region"
-            aria-labelledby="case-example-heading"
-            style={{ contentVisibility: "auto" }}
-        >
-            <Container>
-                <h2 id="case-example-heading">Case examples</h2>
-                <Card className={styles.caseExample} title="Global fintech">
-                    <p>
-                        <strong>Before:</strong> fragmented widgets, duplicated
-                        effort, inaccessible flows.
-                    </p>
-                    <p>
-                        <strong>After:</strong> unified tokens, audited
-                        patterns—CI checks keep regressions out, –38% UI bugs
-                        per release, +24% velocity on UI tickets, 95th pctl
-                        route paint &lt; 1.2s.
-                    </p>
-                </Card>
-            </Container>
-        </section>
+        <Section id="case-example" heading="Case examples">
+            <Card className={styles.caseExample} title="Global fintech">
+                <p>
+                    <strong>Before:</strong> fragmented widgets, duplicated
+                    effort, inaccessible flows.
+                </p>
+                <p>
+                    <strong>After:</strong> unified tokens, audited patterns—CI
+                    checks keep regressions out, –38% UI bugs per release, +24%
+                    velocity on UI tickets, 95th pctl route paint &lt; 1.2s.
+                </p>
+            </Card>
+        </Section>
     );
 }

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -4,10 +4,11 @@ import styles from "./Contact.module.scss";
 
 export default function Contact() {
     return (
-        <Section id="contact" labelledBy="contact-heading">
-            <h2 id="contact-heading" className={styles.heading}>
-                Ready to ship?
-            </h2>
+        <Section
+            id="contact"
+            heading="Ready to ship?"
+            headingClassName={styles.heading}
+        >
             <div className={styles.ctaGroup}>
                 <Button href="mailto:hello@lapidist.net">
                     Book a 20-min discovery call

--- a/components/Pledge/Pledge.tsx
+++ b/components/Pledge/Pledge.tsx
@@ -4,14 +4,18 @@ import styles from "./Pledge.module.scss";
 
 export default function Pledge() {
     return (
-        <Section labelledBy="pledge-heading">
-            <h2 id="pledge-heading">
+        <Section
+            id="pledge"
+            heading={
                 <VisuallyHidden>
                     Accessibility &amp; Performance pledge
                 </VisuallyHidden>
-            </h2>
+            }
+        >
             <details>
-                <summary>View my Accessibility &amp; Performance pledge</summary>
+                <summary>
+                    View my Accessibility &amp; Performance pledge
+                </summary>
                 <dl className={styles.checklist}>
                     <div>
                         <dt>Keyboard-first:</dt>

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,9 +1,12 @@
-import type { ReactNode, CSSProperties } from "react";
+import type { CSSProperties, ElementType, ReactNode } from "react";
 import Container from "@/components/Container/Container";
 
 interface Props {
     id?: string;
-    labelledBy: string;
+    labelledBy?: string;
+    heading?: ReactNode;
+    headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+    headingClassName?: string;
     className?: string;
     containerSize?: "s" | "m" | "l";
     style?: CSSProperties;
@@ -14,6 +17,9 @@ interface Props {
 export default function Section({
     id,
     labelledBy,
+    heading,
+    headingLevel = 2,
+    headingClassName,
     className,
     containerSize,
     style,
@@ -24,15 +30,27 @@ export default function Section({
         ? ({ contentVisibility: "auto", ...style } as CSSProperties)
         : style;
 
+    const headingId = heading
+        ? (labelledBy ?? (id ? `${id}-heading` : undefined))
+        : labelledBy;
+    const HeadingTag = `h${String(headingLevel)}` as ElementType;
+
     return (
         <section
             id={id}
             role="region"
-            aria-labelledby={labelledBy}
+            aria-labelledby={headingId}
             className={className}
             style={sectionStyle}
         >
-            <Container size={containerSize}>{children}</Container>
+            <Container size={containerSize}>
+                {heading && (
+                    <HeadingTag id={headingId} className={headingClassName}>
+                        {heading}
+                    </HeadingTag>
+                )}
+                {children}
+            </Container>
         </section>
     );
 }

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -4,8 +4,7 @@ import styles from "./Services.module.scss";
 
 export default function Services() {
     return (
-        <Section id="services" labelledBy="services-heading">
-            <h2 id="services-heading">Signature services</h2>
+        <Section id="services" heading="Signature services">
             <div className={styles.cards}>
                 <Card title="Design System Bootstrap" highlight>
                     <p>Launch a production-ready design system in weeks.</p>
@@ -15,9 +14,7 @@ export default function Services() {
                     <p>
                         Turn your existing assets into a clear system strategy.
                     </p>
-                    <p>
-                        Receive a practical roadmap to grow what you have.
-                    </p>
+                    <p>Receive a practical roadmap to grow what you have.</p>
                 </Card>
                 <Card title="Hands-on Build">
                     <p>
@@ -28,7 +25,8 @@ export default function Services() {
                 </Card>
                 <Card title="Advisory & Team Uplift">
                     <p>
-                        Grow your team&apos;s capabilities with ongoing guidance.
+                        Grow your team&apos;s capabilities with ongoing
+                        guidance.
                     </p>
                     <p>
                         Raise quality through tailored standards, coaching and

--- a/components/WhatIBring/WhatIBring.tsx
+++ b/components/WhatIBring/WhatIBring.tsx
@@ -3,8 +3,7 @@ import styles from "./WhatIBring.module.scss";
 
 export default function WhatIBring() {
     return (
-        <Section labelledBy="problem-to-solution-heading">
-            <h2 id="problem-to-solution-heading">What I bring to the table</h2>
+        <Section id="what-i-bring" heading="What I bring to the table">
             <p>I bridge the gap between product, design and engineering.</p>
             <p>
                 My work has shaped everything from small internal tools to


### PR DESCRIPTION
## Summary
- allow Section to render a heading internally
- use new Section heading prop across content sections

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689ba0976b94832883c7c467e4d62674