### PR TITLE
feat: add wave divider between hero and trusted sections

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -13,6 +13,17 @@
         width: 100%;
         height: 100%;
         display: block;
+        z-index: -2;
+        pointer-events: none;
+    }
+
+    .heroWave {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 4rem;
+        display: block;
         z-index: -1;
         pointer-events: none;
     }

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -145,6 +145,17 @@ export default function Hero() {
                     <p className={styles.note}>No email gate.</p>
                 </div>
             </div>
+            <svg
+                aria-hidden="true"
+                className={styles.heroWave}
+                preserveAspectRatio="none"
+                viewBox="0 0 1440 100"
+            >
+                <path
+                    d="M0 100c240-80 480 80 720 0s480-80 720 0V0H0z"
+                    fill="var(--bg)"
+                />
+            </svg>
         </Section>
     );
 }


### PR DESCRIPTION
## Summary
- add wave SVG divider at hero bottom to blend into next section
- expose styling hook for divider

## Testing
- `npm run lint`
- `npm test` *(fails: accessibility expectation violated)*

------
https://chatgpt.com/codex/tasks/task_e_689c013f6c1c8328adc25d6e73ac11a5