### PR TITLE
chore: remove unused css selectors

### DIFF
--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -44,12 +44,4 @@
         fill: currentcolor;
     }
 
-    .nav {
-        list-style: none;
-        display: flex;
-        gap: var(--space-m);
-        margin: 0;
-        padding: 0;
-        font-size: var(--step-0);
-    }
 }

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -7,7 +7,7 @@ export default function Services() {
     return (
         <Section id="services" heading="Signature services">
             <div className={styles.cards}>
-                <Card title="Design System Bootstrap" className={styles.card}>
+                <Card title="Design System Bootstrap">
                     <svg
                         className={styles.icon}
                         aria-hidden="true"

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -153,15 +153,4 @@
         background: var(--bg);
     }
 
-    .visually-hidden {
-        position: absolute !important;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip-path: inset(50%);
-        white-space: nowrap;
-        border: 0;
-    }
 }


### PR DESCRIPTION
## Summary
- remove unused `.visually-hidden` utility
- drop unused `.nav` styles from header
- eliminate dead `styles.card` reference in services

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cc5d0060c83288ad9e1a4ec4f1682