### PR TITLE
feat(tokens): add icon size tokens

### DIFF
--- a/components/CaseStudies/CaseStudies.module.scss
+++ b/components/CaseStudies/CaseStudies.module.scss
@@ -20,7 +20,7 @@
     .cards {
         display: grid;
         text-align: initial;
-        gap: var(--space-md);
+        gap: var(--space-l);
         margin-block-start: var(--space-l);
     }
 

--- a/components/Services/Services.module.scss
+++ b/components/Services/Services.module.scss
@@ -8,8 +8,8 @@
     }
 
     .icon {
-        width: 48px;
-        height: 48px;
+        width: var(--size-icon-l);
+        height: var(--size-icon-l);
         border-radius: var(--radius-s);
         margin-block-end: var(--space-s);
     }

--- a/components/ThemeToggle/ThemeToggle.module.scss
+++ b/components/ThemeToggle/ThemeToggle.module.scss
@@ -13,8 +13,8 @@
     }
 
     .icon {
-        inline-size: 1.25rem;
-        block-size: 1.25rem;
+        inline-size: var(--size-icon-m);
+        block-size: var(--size-icon-m);
         fill: currentcolor;
     }
 }

--- a/styles/tokens.scss
+++ b/styles/tokens.scss
@@ -1,3 +1,6 @@
+$size-icon-m: 1.25rem;
+$size-icon-l: 3rem;
+
 :root {
     color-scheme: light dark;
 
@@ -56,6 +59,8 @@
 
     /* sizes */
     --size-tap-min: 44px;
+    --size-icon-m: 1.25rem;
+    --size-icon-l: 3rem;
 
     /* radius */
     --radius-xs: 2px;


### PR DESCRIPTION
## Summary
- add reusable icon size tokens
- replace hardcoded icon dimensions with tokens
- fix case studies spacing token typo

## Testing
- `npm run lint`
- `npm test` *(fails: accessibility violations)*

------
https://chatgpt.com/codex/tasks/task_e_689ccaec64c083289651b8cf43ddceae