### PR TITLE
chore: remove unused ArticleMeta export

### DIFF
--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -5,7 +5,7 @@ import { compileMDX } from "next-mdx-remote/rsc";
 
 const ARTICLES_PATH = path.join(process.cwd(), "content", "articles");
 
-export interface ArticleMeta {
+interface ArticleMeta {
     year: string;
     slug: string;
     title: string;


### PR DESCRIPTION
## Summary
- remove unused ArticleMeta export in lib/articles.ts

## Testing
- `npm run lint:js`
- `npm run typecheck`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689cd049b870832890d86dcadd6bf3f7