### PR TITLE
refactor: reuse scss via mixins

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -1,8 +1,9 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
+        @include inline-center;
+
         border: 1px solid transparent;
         cursor: pointer;
         font: inherit;

--- a/components/CaseStudies/CaseStudies.module.scss
+++ b/components/CaseStudies/CaseStudies.module.scss
@@ -7,9 +7,7 @@
     }
 
     .caseStudies > div {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+        @include centered-column;
     }
 
     .tagline {
@@ -18,10 +16,9 @@
     }
 
     .cards {
-        display: grid;
+        @include card-grid(var(--space-l));
+
         text-align: initial;
-        gap: var(--space-l);
-        margin-block-start: var(--space-l);
     }
 
     .visual {
@@ -46,9 +43,7 @@
 
     .cta {
         @include cta-group;
-
-        flex-direction: column;
-        align-items: center;
+        @include centered-column;
     }
 
     @container (min-width:50rem) {

--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -1,34 +1,28 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .footer {
+        @include centered-column;
+
         padding-block: var(--space-xl);
         border-block-start: 1px solid var(--border);
         font-size: var(--step-negative-1);
         text-align: center;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
         color: var(--text-subtle);
     }
 
     .footerContainer {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .footerNav,
-    .social {
-        list-style: none;
-        padding: 0;
-        display: flex;
-        gap: var(--space-s);
-        align-items: center;
-        justify-content: center;
+        @include centered-column;
     }
 
     .footerNav {
-        flex-wrap: wrap;
+        @include centered-list(var(--space-s), true);
+
         margin-block-end: var(--space-m);
+    }
+
+    .social {
+        @include centered-list(var(--space-s));
     }
 
     .footer p {
@@ -37,9 +31,8 @@
 
     .footerNav a,
     .social a {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
+        @include inline-center;
+
         min-block-size: var(--size-tap-min);
         min-inline-size: var(--size-tap-min);
         text-decoration: none;

--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -26,9 +26,8 @@
     }
 
     .cta {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+        @include centered-column;
+
         gap: var(--space-2xs);
         margin-bottom: var(--space-2xl);
     }

--- a/components/Insights/Insights.module.scss
+++ b/components/Insights/Insights.module.scss
@@ -1,18 +1,16 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .insights {
         background: var(--surface);
     }
 
     .insights > div {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+        @include centered-column;
     }
 
     .cards {
-        display: grid;
-        gap: var(--space-xl);
-        margin-block-start: var(--space-l);
+        @include card-grid();
     }
 
     @container (min-width:50rem) {

--- a/components/Services/Services.module.scss
+++ b/components/Services/Services.module.scss
@@ -2,9 +2,7 @@
 
 @layer components {
     .cards {
-        display: grid;
-        gap: var(--space-xl);
-        margin-block-start: var(--space-l);
+        @include card-grid();
     }
 
     .icon {
@@ -16,9 +14,7 @@
 
     .cta {
         @include cta-group;
-
-        flex-direction: column;
-        align-items: center;
+        @include centered-column;
     }
 
     @container (min-width:50rem) {

--- a/components/Testimonials/Testimonials.module.scss
+++ b/components/Testimonials/Testimonials.module.scss
@@ -6,18 +6,16 @@
     }
 
     .cards {
-        display: grid;
-        gap: var(--space-xl);
-        margin-block-start: var(--space-l);
+        @include card-grid();
     }
 
     .card {
         background: var(--surface);
         padding: var(--space-l);
         border-radius: var(--radius-l);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+
+        @include centered-column;
+
         gap: var(--space-m);
     }
 

--- a/components/ThemeToggle/ThemeToggle.module.scss
+++ b/components/ThemeToggle/ThemeToggle.module.scss
@@ -1,8 +1,9 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .toggle {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
+        @include inline-center;
+
         min-block-size: var(--size-tap-min);
         min-inline-size: var(--size-tap-min);
         padding: var(--space-xs);

--- a/components/TrustedBy/TrustedBy.module.scss
+++ b/components/TrustedBy/TrustedBy.module.scss
@@ -2,9 +2,7 @@
 
 @layer components {
     .trustedBy > div {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+        @include centered-column;
     }
 
     .tagline {
@@ -13,12 +11,7 @@
     }
 
     .logos {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--space-l);
-        list-style: none;
-        justify-content: center;
-        padding: 0;
+        @include centered-list(var(--space-l), true);
     }
 
     .logo {

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -58,3 +58,34 @@
     justify-content: center;
     margin-block-start: var(--space-2xl);
 }
+
+@mixin centered-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+@mixin inline-center {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@mixin centered-list($gap, $wrap: false) {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    gap: $gap;
+    align-items: center;
+    justify-content: center;
+
+    @if $wrap {
+        flex-wrap: wrap;
+    }
+}
+
+@mixin card-grid($gap: var(--space-xl)) {
+    display: grid;
+    gap: $gap;
+    margin-block-start: var(--space-l);
+}


### PR DESCRIPTION
## Summary
- extract common layout patterns into mixins
- refactor component styles to consume new mixins

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd2f00990832889777211da57848e