### PR TITLE
refactor: centralize common CTAs

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react";
+import clsx from "clsx";
 import type {
     AnchorHTMLAttributes,
     ButtonHTMLAttributes,
@@ -37,7 +38,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
         },
         ref,
     ) => {
-        const classes = [styles.button, className].filter(Boolean).join(" ");
+        const classes = clsx(styles.button, className);
         const data = {
             "data-variant": variant,
             "data-size": size,

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -1,4 +1,5 @@
 import type { ElementType, ReactNode } from "react";
+import clsx from "clsx";
 import styles from "./Card.module.scss";
 
 interface Props {
@@ -21,7 +22,7 @@ export default function Card({
     className,
 }: Props) {
     const Heading = headingLevel as ElementType;
-    const classes = [styles.card, className].filter(Boolean).join(" ");
+    const classes = clsx(styles.card, className);
     return (
         <Component
             className={classes}

--- a/components/CaseStudies/CaseStudies.tsx
+++ b/components/CaseStudies/CaseStudies.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button/Button";
+import { BookCallButton } from "@/components/Cta/Cta";
 import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import styles from "./CaseStudies.module.scss";
@@ -504,7 +504,7 @@ export default function CaseStudies() {
             </div>
             <div className={styles.cta}>
                 <p>Want these results for your team?</p>
-                <Button href="#contact">Book a call</Button>
+                <BookCallButton />
             </div>
         </Section>
     );

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,5 +1,5 @@
-import Button from "@/components/Button/Button";
 import Section from "@/components/Section/Section";
+import { BookCallButton, DownloadDeckButton } from "@/components/Cta/Cta";
 import styles from "./Contact.module.scss";
 
 export default function Contact() {
@@ -9,10 +9,8 @@ export default function Contact() {
                 Ready to talk?
             </h2>
             <div className={styles.ctaGroup}>
-                <Button href="mailto:hello@lapidist.net">Book a call</Button>
-                <Button href="/brett-dorrans-cv.pdf" variant="secondary">
-                    Download capabilities deck
-                </Button>
+                <BookCallButton href="mailto:hello@lapidist.net" />
+                <DownloadDeckButton />
             </div>
         </Section>
     );

--- a/components/Container/Container.tsx
+++ b/components/Container/Container.tsx
@@ -1,4 +1,5 @@
 import type { ElementType, ReactNode } from "react";
+import clsx from "clsx";
 import styles from "./Container.module.scss";
 
 interface Props {
@@ -16,7 +17,7 @@ export default function Container({
     className,
     children,
 }: Props) {
-    const classes = [styles.container, className].filter(Boolean).join(" ");
+    const classes = clsx(styles.container, className);
     return (
         <Component
             className={classes}

--- a/components/Cta/Cta.tsx
+++ b/components/Cta/Cta.tsx
@@ -1,0 +1,36 @@
+import Button from "@/components/Button/Button";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+interface Props extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+    variant?: "primary" | "secondary" | "ghost";
+    size?: "md" | "lg";
+    loading?: boolean;
+    className?: string;
+    children?: ReactNode;
+    href?: string;
+}
+
+export function BookCallButton({
+    children = "Book a call",
+    href = "#contact",
+    ...props
+}: Props) {
+    return (
+        <Button href={href} {...props}>
+            {children}
+        </Button>
+    );
+}
+
+export function DownloadDeckButton({
+    children = "Download capabilities deck",
+    href = "/brett-dorrans-cv.pdf",
+    variant = "secondary",
+    ...props
+}: Props) {
+    return (
+        <Button href={href} variant={variant} {...props}>
+            {children}
+        </Button>
+    );
+}

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,5 +1,5 @@
-import Button from "@/components/Button/Button";
 import Section from "@/components/Section/Section";
+import { BookCallButton, DownloadDeckButton } from "@/components/Cta/Cta";
 import styles from "./Hero.module.scss";
 
 export default function Hero() {
@@ -21,19 +21,13 @@ export default function Hero() {
             </div>
             <div className={styles.ctaGroup}>
                 <div className={styles.cta}>
-                    <Button href="#contact" size="lg">
+                    <BookCallButton size="lg">
                         Book a 20-min discovery call
-                    </Button>
+                    </BookCallButton>
                     <p className={styles.note}>Let&apos;s chat.</p>
                 </div>
                 <div className={styles.cta}>
-                    <Button
-                        href="/brett-dorrans-cv.pdf"
-                        variant="secondary"
-                        size="lg"
-                    >
-                        Download capabilities deck
-                    </Button>
+                    <DownloadDeckButton size="lg" />
                     <p className={styles.note}>No email required.</p>
                 </div>
             </div>

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -1,5 +1,5 @@
-import Button from "@/components/Button/Button";
 import Card from "@/components/Card/Card";
+import { BookCallButton } from "@/components/Cta/Cta";
 import Section from "@/components/Section/Section";
 import styles from "./Services.module.scss";
 
@@ -105,7 +105,7 @@ export default function Services() {
             </div>
             <div className={styles.cta}>
                 <p>Let&apos;s discuss which options fit your team.</p>
-                <Button href="#contact">Book a call</Button>
+                <BookCallButton />
             </div>
         </Section>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@lapidist/cv-generator": "2.4.0",
+                "clsx": "^2.1.1",
                 "gray-matter": "^4.0.3",
                 "next": "15.4.6",
                 "next-mdx-remote": "^5.0.0",
@@ -9263,6 +9264,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/collapse-white-space": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     },
     "dependencies": {
         "@lapidist/cv-generator": "2.4.0",
+        "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
         "next": "15.4.6",
         "next-mdx-remote": "^5.0.0",


### PR DESCRIPTION
## Summary
- add BookCallButton and DownloadDeckButton components for shared CTAs
- replace repeated CTA markup in hero, contact, services and case studies
- use `clsx` for class merging and install dependency

## Testing
- `npm run lint`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689ce200753083289127654eb5da0ac7