### PR TITLE
Add missing Storybook stories and variants

### DIFF
--- a/components/Card/Card.stories.tsx
+++ b/components/Card/Card.stories.tsx
@@ -22,3 +22,7 @@ export const Highlighted: Story = {
 export const Large: Story = {
     args: { size: "lg" },
 };
+
+export const HeadingLevel4: Story = {
+    args: { headingLevel: "h4" },
+};

--- a/components/CaseStudies/CaseStudies.stories.tsx
+++ b/components/CaseStudies/CaseStudies.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import CaseStudies from "./CaseStudies";
+
+const meta = {
+    title: "Components/CaseStudies",
+    component: CaseStudies,
+} satisfies Meta<typeof CaseStudies>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/components/Container/Container.stories.tsx
+++ b/components/Container/Container.stories.tsx
@@ -25,3 +25,7 @@ export const Large: Story = {
 export const Article: Story = {
     args: { as: "article" },
 };
+
+export const Page: Story = {
+    args: { cq: "page" },
+};

--- a/components/Insights/Insights.stories.tsx
+++ b/components/Insights/Insights.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import Insights from "./Insights";
+
+const meta = {
+    title: "Components/Insights",
+    component: Insights,
+} satisfies Meta<typeof Insights>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/components/Section/Section.stories.tsx
+++ b/components/Section/Section.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import Section from "./Section";
+
+const meta = {
+    title: "Components/Section",
+    component: Section,
+    args: {
+        heading: "Section heading",
+        children: "Section content",
+    },
+} satisfies Meta<typeof Section>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Small: Story = {
+    args: { containerSize: "s" },
+};
+
+export const Large: Story = {
+    args: { containerSize: "l" },
+};
+
+export const HeadingLevel3: Story = {
+    args: { headingLevel: 3 },
+};
+
+export const WithoutHeading: Story = {
+    args: { heading: undefined },
+};
+
+export const ContentVisibilityOff: Story = {
+    args: { contentVisibility: false },
+};

--- a/components/Testimonials/Testimonials.stories.tsx
+++ b/components/Testimonials/Testimonials.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import Testimonials from "./Testimonials";
+
+const meta = {
+    title: "Components/Testimonials",
+    component: Testimonials,
+} satisfies Meta<typeof Testimonials>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/components/TrustedBy/TrustedBy.stories.tsx
+++ b/components/TrustedBy/TrustedBy.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import TrustedBy from "./TrustedBy";
+
+const meta = {
+    title: "Components/TrustedBy",
+    component: TrustedBy,
+} satisfies Meta<typeof TrustedBy>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- add Storybook stories for CaseStudies, Insights, Section, Testimonials, and TrustedBy components
- cover remaining variants for Card and Container stories

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce6b6bae8832896e4d75545f040b9