### PR TITLE
add story for Cta component

### DIFF
--- a/components/Cta/Cta.stories.tsx
+++ b/components/Cta/Cta.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { BookCallButton, DownloadDeckButton } from "./Cta";
+
+const meta = {
+    title: "Components/Cta",
+    component: BookCallButton,
+} satisfies Meta<typeof BookCallButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BookCallPrimary: Story = {};
+
+export const BookCallSecondary: Story = {
+    args: { variant: "secondary" },
+};
+
+export const BookCallGhost: Story = {
+    args: { variant: "ghost" },
+};
+
+export const DownloadDeckSecondary: Story = {
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckPrimary: Story = {
+    args: { variant: "primary" },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckGhost: Story = {
+    args: { variant: "ghost" },
+    render: (args) => <DownloadDeckButton {...args} />,
+};


### PR DESCRIPTION
## Summary
- add Storybook coverage for Cta buttons

## Testing
- `npm run lint`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689cebe848008328988234cb8fda1c62