### PR TITLE
chore: expand storybook coverage

### DIFF
--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -27,8 +27,36 @@ export const Large: Story = {
     args: { size: "lg" },
 };
 
+export const LargeLoading: Story = {
+    args: { size: "lg", loading: true },
+};
+
 export const Loading: Story = {
     args: { loading: true },
+};
+
+export const SecondaryLarge: Story = {
+    args: { variant: "secondary", size: "lg" },
+};
+
+export const SecondaryLoading: Story = {
+    args: { variant: "secondary", loading: true },
+};
+
+export const SecondaryLargeLoading: Story = {
+    args: { variant: "secondary", size: "lg", loading: true },
+};
+
+export const GhostLarge: Story = {
+    args: { variant: "ghost", size: "lg" },
+};
+
+export const GhostLoading: Story = {
+    args: { variant: "ghost", loading: true },
+};
+
+export const GhostLargeLoading: Story = {
+    args: { variant: "ghost", size: "lg", loading: true },
 };
 
 export const AsLink: Story = {
@@ -59,3 +87,4 @@ export const AsLinkWithRef: Story = {
         return <Button ref={ref} {...args} />;
     },
 };
+

--- a/components/Card/Card.stories.tsx
+++ b/components/Card/Card.stories.tsx
@@ -23,6 +23,22 @@ export const Large: Story = {
     args: { size: "lg" },
 };
 
+export const LargeHighlighted: Story = {
+    args: { size: "lg", highlight: true },
+};
+
 export const HeadingLevel4: Story = {
     args: { headingLevel: "h4" },
+};
+
+export const HeadingLevel4Highlighted: Story = {
+    args: { headingLevel: "h4", highlight: true },
+};
+
+export const LargeHeadingLevel4: Story = {
+    args: { size: "lg", headingLevel: "h4" },
+};
+
+export const LargeHeadingLevel4Highlighted: Story = {
+    args: { size: "lg", headingLevel: "h4", highlight: true },
 };

--- a/components/Container/Container.stories.tsx
+++ b/components/Container/Container.stories.tsx
@@ -29,3 +29,11 @@ export const Article: Story = {
 export const Page: Story = {
     args: { cq: "page" },
 };
+
+export const SmallPage: Story = {
+    args: { size: "s", cq: "page" },
+};
+
+export const LargePage: Story = {
+    args: { size: "l", cq: "page" },
+};

--- a/components/Cta/Cta.stories.tsx
+++ b/components/Cta/Cta.stories.tsx
@@ -19,6 +19,18 @@ export const BookCallGhost: Story = {
     args: { variant: "ghost" },
 };
 
+export const BookCallLarge: Story = {
+    args: { size: "lg" },
+};
+
+export const BookCallLoading: Story = {
+    args: { loading: true },
+};
+
+export const BookCallLargeLoading: Story = {
+    args: { size: "lg", loading: true },
+};
+
 export const DownloadDeckSecondary: Story = {
     render: (args) => <DownloadDeckButton {...args} />,
 };
@@ -30,5 +42,20 @@ export const DownloadDeckPrimary: Story = {
 
 export const DownloadDeckGhost: Story = {
     args: { variant: "ghost" },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckLarge: Story = {
+    args: { size: "lg" },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckLoading: Story = {
+    args: { loading: true },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckLargeLoading: Story = {
+    args: { size: "lg", loading: true },
     render: (args) => <DownloadDeckButton {...args} />,
 };

--- a/components/Section/Section.stories.tsx
+++ b/components/Section/Section.stories.tsx
@@ -27,6 +27,14 @@ export const HeadingLevel3: Story = {
     args: { headingLevel: 3 },
 };
 
+export const SmallHeadingLevel3: Story = {
+    args: { containerSize: "s", headingLevel: 3 },
+};
+
+export const LargeHeadingLevel3: Story = {
+    args: { containerSize: "l", headingLevel: 3 },
+};
+
 export const WithoutHeading: Story = {
     args: { heading: undefined },
 };


### PR DESCRIPTION
## Summary
- add missing variant combinations for Button stories
- expand Card, Container, Cta, and Section stories to cover all prop combinations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ceefb8f94832892418a921663e591