### PR TITLE
Add complete variant coverage to Section and CTA stories

### DIFF
--- a/components/Cta/Cta.stories.tsx
+++ b/components/Cta/Cta.stories.tsx
@@ -31,6 +31,30 @@ export const BookCallLargeLoading: Story = {
     args: { size: "lg", loading: true },
 };
 
+export const BookCallSecondaryLarge: Story = {
+    args: { variant: "secondary", size: "lg" },
+};
+
+export const BookCallSecondaryLoading: Story = {
+    args: { variant: "secondary", loading: true },
+};
+
+export const BookCallSecondaryLargeLoading: Story = {
+    args: { variant: "secondary", size: "lg", loading: true },
+};
+
+export const BookCallGhostLarge: Story = {
+    args: { variant: "ghost", size: "lg" },
+};
+
+export const BookCallGhostLoading: Story = {
+    args: { variant: "ghost", loading: true },
+};
+
+export const BookCallGhostLargeLoading: Story = {
+    args: { variant: "ghost", size: "lg", loading: true },
+};
+
 export const DownloadDeckSecondary: Story = {
     render: (args) => <DownloadDeckButton {...args} />,
 };
@@ -57,5 +81,35 @@ export const DownloadDeckLoading: Story = {
 
 export const DownloadDeckLargeLoading: Story = {
     args: { size: "lg", loading: true },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckPrimaryLarge: Story = {
+    args: { variant: "primary", size: "lg" },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckPrimaryLoading: Story = {
+    args: { variant: "primary", loading: true },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckPrimaryLargeLoading: Story = {
+    args: { variant: "primary", size: "lg", loading: true },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckGhostLarge: Story = {
+    args: { variant: "ghost", size: "lg" },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckGhostLoading: Story = {
+    args: { variant: "ghost", loading: true },
+    render: (args) => <DownloadDeckButton {...args} />,
+};
+
+export const DownloadDeckGhostLargeLoading: Story = {
+    args: { variant: "ghost", size: "lg", loading: true },
     render: (args) => <DownloadDeckButton {...args} />,
 };

--- a/components/Section/Section.stories.tsx
+++ b/components/Section/Section.stories.tsx
@@ -15,12 +15,24 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Small: Story = {
-    args: { containerSize: "s" },
+export const SmallHeadingLevel1: Story = {
+    args: { containerSize: "s", headingLevel: 1 },
 };
 
-export const Large: Story = {
-    args: { containerSize: "l" },
+export const HeadingLevel1: Story = {
+    args: { headingLevel: 1 },
+};
+
+export const LargeHeadingLevel1: Story = {
+    args: { containerSize: "l", headingLevel: 1 },
+};
+
+export const SmallHeadingLevel2: Story = {
+    args: { containerSize: "s", headingLevel: 2 },
+};
+
+export const LargeHeadingLevel2: Story = {
+    args: { containerSize: "l", headingLevel: 2 },
 };
 
 export const HeadingLevel3: Story = {
@@ -33,6 +45,42 @@ export const SmallHeadingLevel3: Story = {
 
 export const LargeHeadingLevel3: Story = {
     args: { containerSize: "l", headingLevel: 3 },
+};
+
+export const HeadingLevel4: Story = {
+    args: { headingLevel: 4 },
+};
+
+export const SmallHeadingLevel4: Story = {
+    args: { containerSize: "s", headingLevel: 4 },
+};
+
+export const LargeHeadingLevel4: Story = {
+    args: { containerSize: "l", headingLevel: 4 },
+};
+
+export const HeadingLevel5: Story = {
+    args: { headingLevel: 5 },
+};
+
+export const SmallHeadingLevel5: Story = {
+    args: { containerSize: "s", headingLevel: 5 },
+};
+
+export const LargeHeadingLevel5: Story = {
+    args: { containerSize: "l", headingLevel: 5 },
+};
+
+export const HeadingLevel6: Story = {
+    args: { headingLevel: 6 },
+};
+
+export const SmallHeadingLevel6: Story = {
+    args: { containerSize: "s", headingLevel: 6 },
+};
+
+export const LargeHeadingLevel6: Story = {
+    args: { containerSize: "l", headingLevel: 6 },
 };
 
 export const WithoutHeading: Story = {


### PR DESCRIPTION
## Summary
- expand Section stories to cover all size/heading combinations
- document every variant of CTA buttons

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format` *(fails: Code style issues found in 8 files)*

------
https://chatgpt.com/codex/tasks/task_e_689cf3c54588832882446fb586e7db2a