### PR TITLE
docs: remove typography section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,6 @@
 
 This repository lives at [lapidist.net](https://lapidist.net)
 
-## Typography
-
-The site uses variable fonts with optical sizing and slant configured via
-`font-variation-settings`. Design tokens are provided for line height and
-measure to keep text rhythm consistent:
-
-- `--font-opsz` – optical size axis
-- `--font-slnt` – slant axis
-- `--leading-tight` and `--leading-normal` – heading and body line heights
-- `--measure` – maximum line length for readable text blocks
-
 ## License
 
 `@lapidist/website` is licensed under the MIT license. See LICENSE for the full text.


### PR DESCRIPTION
## Summary
- remove typography section from the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cfd4c37008328a88d55189ff6db13