### PR TITLE
Include articles in sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,23 @@
 import type { MetadataRoute } from "next";
+import { getAllArticles } from "@/lib/articles";
 
 export const dynamic = "force-static";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const articles = await getAllArticles();
+    const articleEntries = articles.map(({ year, slug, date }) => ({
+        url: `https://lapidist.net/${year}/${slug}`,
+        lastModified: new Date(date),
+    }));
     return [
         {
             url: "https://lapidist.net",
             lastModified: new Date(),
         },
+        {
+            url: "https://lapidist.net/articles",
+            lastModified: new Date(),
+        },
+        ...articleEntries,
     ];
 }

--- a/tests/sitemap.spec.ts
+++ b/tests/sitemap.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "@playwright/test";
+
+test("sitemap includes articles", async ({ request }) => {
+    const response = await request.get("/sitemap.xml");
+    expect(response.ok()).toBeTruthy();
+    const xml = await response.text();
+    expect(xml).toContain(
+        "https://lapidist.net/2025/on-freedom-curiosity-and-happiness",
+    );
+});


### PR DESCRIPTION
## Summary
- generate sitemap entries for the articles index and each article page
- add test ensuring sitemap includes article URLs

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689db902c67883289d4e04b9958b1e07