### PR TITLE
Add accessible error pages and article tests

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -12,7 +12,7 @@ export default async function ArticlesPage() {
             <div className={styles.cards}>
                 {articles.map(({ year, slug, title, description }) => (
                     <Link key={`${year}-${slug}`} href={`/${year}/${slug}`}>
-                        <Card title={title}>
+                        <Card title={title} headingLevel="h2">
                             <p>{description}</p>
                         </Card>
                     </Link>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Link from "next/link";
+import Section from "@/components/Section/Section";
+
+export default function Error() {
+    return (
+        <Section heading="Something went wrong" headingLevel={1}>
+            <p>Sorry, an unexpected error occurred.</p>
+            <p>
+                <Link href="/">Return home</Link>
+            </p>
+        </Section>
+    );
+}

--- a/app/force-error/page.tsx
+++ b/app/force-error/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ForceErrorPage() {
+    useEffect(() => {
+        throw new Error("Forced error");
+    }, []);
+    return null;
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import Section from "@/components/Section/Section";
+
+export default function NotFound() {
+    return (
+        <Section heading="Page not found" headingLevel={1}>
+            <p>
+                Sorry, we couldn&apos;t find the page you&apos;re looking for.
+            </p>
+            <p>
+                <Link href="/">Return home</Link>
+            </p>
+        </Section>
+    );
+}

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -7,7 +7,7 @@ interface Props {
     title: string;
     highlight?: boolean;
     children: ReactNode;
-    headingLevel?: "h3" | "h4";
+    headingLevel?: "h2" | "h3" | "h4";
     size?: "md" | "lg";
     className?: string;
     icon?: ReactNode;

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -38,7 +38,6 @@ export default function Section({
     return (
         <section
             id={id}
-            role="region"
             aria-labelledby={headingId}
             className={className}
             style={sectionStyle}

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -1,0 +1,22 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("articles index is accessible", async ({ page }) => {
+    await page.goto("/articles");
+    await expect(page.locator("h1")).toContainText("Articles");
+    const accessibilityScanResults = await new AxeBuilder({ page })
+        .include("main")
+        .exclude('[role="alert"]')
+        .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("article page is accessible", async ({ page }) => {
+    await page.goto("/2025/on-freedom-curiosity-and-happiness");
+    await expect(page.locator("article")).toBeVisible();
+    const accessibilityScanResults = await new AxeBuilder({ page })
+        .include("main")
+        .exclude('[role="alert"]')
+        .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+});

--- a/tests/error-pages.spec.ts
+++ b/tests/error-pages.spec.ts
@@ -1,0 +1,22 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("404 page has no accessibility violations", async ({ page }) => {
+    await page.goto("/non-existent");
+    await expect(page.locator("h1")).toContainText("Page not found");
+    const accessibilityScanResults = await new AxeBuilder({ page })
+        .include("main")
+        .exclude('[role="alert"]')
+        .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test("500 page has no accessibility violations", async ({ page }) => {
+    await page.goto("/force-error");
+    await expect(page.locator("h1")).toContainText("Something went wrong");
+    const accessibilityScanResults = await new AxeBuilder({ page })
+        .include("main")
+        .exclude('[role="alert"]')
+        .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add custom 404 and error pages with links back home
- allow card headings to use `h2` and fix heading order on articles index
- add Playwright checks for article and error pages

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dbdaa52c8832886c24eb8152df28a