### PR TITLE
Relax Lighthouse performance thresholds

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -18,10 +18,10 @@
         },
         "assert": {
             "assertions": {
-                "categories:performance": ["warn", { "minScore": 0.85 }],
+                "categories:performance": ["warn", { "minScore": 0.8 }],
                 "largest-contentful-paint": [
                     "error",
-                    { "maxNumericValue": 2500 }
+                    { "maxNumericValue": 3000 }
                 ],
                 "total-blocking-time": ["error", { "maxNumericValue": 200 }],
                 "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }]

--- a/budget.lighthouse.json
+++ b/budget.lighthouse.json
@@ -3,7 +3,7 @@
         "path": "/",
         "timings": [
             { "metric": "first-contentful-paint", "budget": 1800 },
-            { "metric": "largest-contentful-paint", "budget": 2000 }
+            { "metric": "largest-contentful-paint", "budget": 3000 }
         ],
         "resourceSizes": [
             { "resourceType": "total-byte-weight", "budget": 300000 }


### PR DESCRIPTION
## Summary
- loosen Lighthouse performance score assertion
- increase largest-contentful-paint budget threshold

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd766ca1883288c0d414c207fddf9