### PR TITLE
Add Framer Motion animations with reduced-motion support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "@/styles/globals.scss";
 import "@/styles/typography.scss";
 import Header from "@/components/Header/Header";
 import styles from "./layout.module.scss";
+import MotionProvider from "./motion-provider";
 
 // Load variable fonts so optical size and slant can be controlled via
 // `font-variation-settings` in CSS.
@@ -227,7 +228,7 @@ export default function RootLayout({
                     Skip to content
                 </a>
                 <Header />
-                <main id="main">{children}</main>
+                <MotionProvider>{children}</MotionProvider>
             </body>
         </html>
     );

--- a/app/motion-provider.tsx
+++ b/app/motion-provider.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+    AnimatePresence,
+    domAnimation,
+    LazyMotion,
+    m,
+    useReducedMotion,
+} from "framer-motion";
+import { usePathname } from "next/navigation";
+
+export default function MotionProvider({ children }: { children: ReactNode }) {
+    const pathname = usePathname();
+    const shouldReduceMotion = useReducedMotion();
+
+    return (
+        <LazyMotion features={domAnimation} strict>
+            <AnimatePresence mode="wait" initial={false}>
+                <m.main
+                    key={pathname}
+                    id="main"
+                    initial={shouldReduceMotion ? "visible" : "hidden"}
+                    animate="visible"
+                    exit={shouldReduceMotion ? undefined : "exit"}
+                    variants={{
+                        hidden: { opacity: 0, y: 20 },
+                        visible: { opacity: 1, y: 0 },
+                        exit: { opacity: 0, y: -20 },
+                    }}
+                    transition={{ duration: 0.25, ease: "easeOut" }}
+                >
+                    {children}
+                </m.main>
+            </AnimatePresence>
+        </LazyMotion>
+    );
+}

--- a/components/Container/Container.tsx
+++ b/components/Container/Container.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ElementType, ReactNode } from "react";
 import clsx from "clsx";
 import styles from "./Container.module.scss";

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -9,6 +9,7 @@ export default function Hero() {
             labelledBy="hero-heading"
             containerSize="l"
             contentVisibility={false}
+            animate={false}
         >
             <div className={styles.ctaGroup}>
                 <h1 id="hero-heading" className={styles.heroTitle}>

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import type { CSSProperties, ElementType, ReactNode } from "react";
+import { useRef } from "react";
+import { m, useInView, useReducedMotion } from "framer-motion";
 import Container from "@/components/Container/Container";
 
 interface Props {
@@ -11,6 +15,7 @@ interface Props {
     containerSize?: "s" | "m" | "l";
     style?: CSSProperties;
     contentVisibility?: boolean;
+    animate?: boolean;
     children: ReactNode;
 }
 
@@ -24,8 +29,13 @@ export default function Section({
     containerSize,
     style,
     contentVisibility = true,
+    animate = true,
     children,
 }: Props) {
+    const ref = useRef<HTMLElement>(null);
+    const isInView = useInView(ref, { once: true, margin: "0px 0px -100px" });
+    const shouldReduceMotion = useReducedMotion();
+
     const sectionStyle = contentVisibility
         ? ({ contentVisibility: "auto", ...style } as CSSProperties)
         : style;
@@ -35,12 +45,53 @@ export default function Section({
         : labelledBy;
     const HeadingTag = `h${String(headingLevel)}` as ElementType;
 
+    const shouldAnimate = animate && !shouldReduceMotion;
+
+    if (!shouldAnimate) {
+        return (
+            <section
+                id={id}
+                aria-labelledby={headingId}
+                className={className}
+                style={sectionStyle}
+            >
+                <Container size={containerSize}>
+                    {heading && (
+                        <HeadingTag id={headingId} className={headingClassName}>
+                            {heading}
+                        </HeadingTag>
+                    )}
+                    {children}
+                </Container>
+            </section>
+        );
+    }
+
     return (
-        <section
+        <m.section
+            ref={ref}
             id={id}
             aria-labelledby={headingId}
+            aria-hidden={!isInView ? true : undefined}
             className={className}
             style={sectionStyle}
+            initial="hidden"
+            animate={isInView ? "visible" : "hidden"}
+            variants={{
+                hidden: {
+                    opacity: 0,
+                    y: 32,
+                    visibility: "hidden",
+                    pointerEvents: "none",
+                },
+                visible: {
+                    opacity: 1,
+                    y: 0,
+                    visibility: "visible",
+                    pointerEvents: "auto",
+                },
+            }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
         >
             <Container size={containerSize}>
                 {heading && (
@@ -50,6 +101,6 @@ export default function Section({
                 )}
                 {children}
             </Container>
-        </section>
+        </m.section>
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@lapidist/cv-generator": "2.4.0",
                 "clsx": "2.1.1",
+                "framer-motion": "^11.18.2",
                 "gray-matter": "4.0.3",
                 "next": "15.4.6",
                 "next-mdx-remote": "5.0.0",
@@ -12148,6 +12149,33 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/framer-motion": {
+            "version": "11.18.2",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+            "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-dom": "^11.18.1",
+                "motion-utils": "^11.18.1",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -15726,6 +15754,21 @@
             "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
             "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/motion-dom": {
+            "version": "11.18.1",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+            "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-utils": "^11.18.1"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "11.18.1",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+            "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
             "license": "MIT"
         },
         "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@lapidist/cv-generator": "2.4.0",
         "clsx": "2.1.1",
+        "framer-motion": "^11.18.2",
         "gray-matter": "4.0.3",
         "next": "15.4.6",
         "next-mdx-remote": "5.0.0",


### PR DESCRIPTION
## Summary
- add Framer Motion and container/client components to enable animations
- animate sections on scroll with reduced-motion fallback
- apply page transitions with a motion provider

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfc9699ac832898fd25d60df55314