### PR TITLE
Add footer to blog pages

### DIFF
--- a/app/[year]/[slug]/page.tsx
+++ b/app/[year]/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import Contact from "@/components/Contact/Contact";
+import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
 import { getAllArticles, getArticle } from "@/lib/articles";
 import styles from "./page.module.scss";
@@ -15,14 +17,18 @@ export default async function ArticlePage({
     const { year, slug } = await params;
     const { meta, content } = await getArticle(year, slug);
     return (
-        <Section heading={meta.title} headingLevel={1}>
-            <article className={styles.article}>
-                {meta.description && (
-                    <p className={styles.description}>{meta.description}</p>
-                )}
-                {content}
-            </article>
-        </Section>
+        <>
+            <Section heading={meta.title} headingLevel={1}>
+                <article className={styles.article}>
+                    {meta.description && (
+                        <p className={styles.description}>{meta.description}</p>
+                    )}
+                    {content}
+                </article>
+            </Section>
+            <Contact />
+            <Footer />
+        </>
     );
 }
 

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,23 +1,29 @@
 import Link from "next/link";
 import Card from "@/components/Card/Card";
+import Contact from "@/components/Contact/Contact";
 import Container from "@/components/Container/Container";
+import Footer from "@/components/Footer/Footer";
 import { getAllArticles } from "@/lib/articles";
 import styles from "./page.module.scss";
 
 export default async function ArticlesPage() {
     const articles = await getAllArticles();
     return (
-        <Container as="section">
-            <h1>Articles</h1>
-            <div className={styles.cards}>
-                {articles.map(({ year, slug, title, description }) => (
-                    <Link key={`${year}-${slug}`} href={`/${year}/${slug}`}>
-                        <Card title={title} headingLevel="h2">
-                            <p>{description}</p>
-                        </Card>
-                    </Link>
-                ))}
-            </div>
-        </Container>
+        <>
+            <Container as="section">
+                <h1>Articles</h1>
+                <div className={styles.cards}>
+                    {articles.map(({ year, slug, title, description }) => (
+                        <Link key={`${year}-${slug}`} href={`/${year}/${slug}`}>
+                            <Card title={title} headingLevel="h2">
+                                <p>{description}</p>
+                            </Card>
+                        </Link>
+                    ))}
+                </div>
+            </Container>
+            <Contact />
+            <Footer />
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- include contact CTA and footer on individual article pages
- include contact CTA and footer on articles index

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e650712748328988659b6bbc21ce3