### PR TITLE
Add social metadata to articles

### DIFF
--- a/app/[year]/[slug]/page.tsx
+++ b/app/[year]/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Section from "@/components/Section/Section";
 import { getAllArticles, getArticle } from "@/lib/articles";
 import styles from "./page.module.scss";
@@ -30,8 +31,28 @@ export async function generateMetadata({
     params,
 }: {
     params: Promise<{ year: string; slug: string }>;
-}) {
+}): Promise<Metadata> {
     const { year, slug } = await params;
     const { meta } = await getArticle(year, slug);
-    return { title: meta.title, description: meta.description };
+    const url = `https://lapidist.net/${year}/${slug}`;
+    return {
+        title: meta.title,
+        description: meta.description,
+        openGraph: {
+            title: meta.title,
+            description: meta.description,
+            url,
+            siteName: "Brett Dorrans",
+            type: "article",
+            publishedTime: meta.date,
+            images: [{ url: "/opengraph-image" }],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: meta.title,
+            description: meta.description,
+            images: ["/twitter-image"],
+        },
+        alternates: { canonical: url },
+    };
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,8 +1,32 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import Card from "@/components/Card/Card";
 import Container from "@/components/Container/Container";
 import { getAllArticles } from "@/lib/articles";
 import styles from "./page.module.scss";
+
+export const metadata: Metadata = {
+    title: "Articles",
+    description:
+        "Articles and writing on design systems, frontend engineering, and accessibility.",
+    openGraph: {
+        title: "Articles",
+        description:
+            "Articles and writing on design systems, frontend engineering, and accessibility.",
+        url: "https://lapidist.net/articles",
+        siteName: "Brett Dorrans",
+        type: "website",
+        images: [{ url: "/opengraph-image" }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Articles",
+        description:
+            "Articles and writing on design systems, frontend engineering, and accessibility.",
+        images: ["/twitter-image"],
+    },
+    alternates: { canonical: "https://lapidist.net/articles" },
+};
 
 export default async function ArticlesPage() {
     const articles = await getAllArticles();

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -20,3 +20,27 @@ test("article page is accessible", async ({ page }) => {
         .analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
 });
+
+test("articles page has social metadata", async ({ page }) => {
+    await page.goto("/articles");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+        "content",
+        "website",
+    );
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+        "content",
+        "summary_large_image",
+    );
+});
+
+test("article page has social metadata", async ({ page }) => {
+    await page.goto("/2025/on-freedom-curiosity-and-happiness");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+        "content",
+        "article",
+    );
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+        "content",
+        "summary_large_image",
+    );
+});


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter metadata to article listing and individual article pages
- test presence of social metadata on articles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e652e98908328a9b777106c2aa5c4