### PR TITLE
feat: enrich article metadata

### DIFF
--- a/app/[year]/[slug]/page.tsx
+++ b/app/[year]/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
@@ -36,8 +37,27 @@ export async function generateMetadata({
     params,
 }: {
     params: Promise<{ year: string; slug: string }>;
-}) {
+}): Promise<Metadata> {
     const { year, slug } = await params;
     const { meta } = await getArticle(year, slug);
-    return { title: meta.title, description: meta.description };
+    const url = `/${year}/${slug}`;
+    return {
+        title: meta.title,
+        description: meta.description,
+        alternates: { canonical: url },
+        openGraph: {
+            title: meta.title,
+            description: meta.description,
+            url,
+            type: "article",
+            publishedTime: meta.date,
+            images: [{ url: "/opengraph-image" }],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: meta.title,
+            description: meta.description,
+            images: ["/twitter-image"],
+        },
+    };
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import Card from "@/components/Card/Card";
 import Contact from "@/components/Contact/Contact";
@@ -5,6 +6,28 @@ import Container from "@/components/Container/Container";
 import Footer from "@/components/Footer/Footer";
 import { getAllArticles } from "@/lib/articles";
 import styles from "./page.module.scss";
+
+export const metadata: Metadata = {
+    title: "Articles",
+    description:
+        "Articles and insights on front-end engineering and design systems.",
+    alternates: { canonical: "/articles" },
+    openGraph: {
+        title: "Articles",
+        description:
+            "Articles and insights on front-end engineering and design systems.",
+        url: "/articles",
+        type: "website",
+        images: [{ url: "/opengraph-image" }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Articles",
+        description:
+            "Articles and insights on front-end engineering and design systems.",
+        images: ["/twitter-image"],
+    },
+};
 
 export default async function ArticlesPage() {
     const articles = await getAllArticles();


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter metadata to individual articles
- include SEO metadata on articles index

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eefb2376c8328a67e74e4aa692687