### PR TITLE
strengthen full-stack positioning

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -10,12 +10,12 @@ import styles from "./page.module.scss";
 export const metadata: Metadata = {
     title: "Articles",
     description:
-        "Articles and insights on front-end engineering and design systems.",
+        "Articles and insights on frontend platforms, API design, and design systems.",
     alternates: { canonical: "/articles" },
     openGraph: {
         title: "Articles",
         description:
-            "Articles and insights on front-end engineering and design systems.",
+            "Articles and insights on frontend platforms, API design, and design systems.",
         url: "/articles",
         type: "website",
         images: [{ url: "/opengraph-image" }],
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
         card: "summary_large_image",
         title: "Articles",
         description:
-            "Articles and insights on front-end engineering and design systems.",
+            "Articles and insights on frontend platforms, API design, and design systems.",
         images: ["/twitter-image"],
     },
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,9 +33,9 @@ const METADATA = {
     name: "Brett Dorrans",
     brand: "Lapidist",
     lang: "en-GB",
-    title: "Principal Frontend Engineer & Design Systems Specialist | Remote UK",
+    title: "Lead Frontend Engineer | Full-stack Capable | Remote UK",
     description:
-        "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.",
+        "Frontend and design systems specialist with hands-on API, data, CI/CD and payments experience.",
     theme: {
         light: "#ffffff",
         dark: "#090909",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,6 +35,13 @@ function buildStructuredData() {
                     "accessibility",
                     "performance",
                     "governance",
+                    "API design",
+                    "data modelling",
+                    "Node.js",
+                    "CI/CD",
+                    "Docker",
+                    "AWS",
+                    "payments",
                 ],
                 sameAs: [
                     "https://linkedin.com/in/brettdorrans",
@@ -88,10 +95,10 @@ function buildStructuredData() {
             },
             {
                 "@type": "Service",
-                "@id": `${base}#design-system-consulting`,
-                name: "Design System Consulting",
+                "@id": `${base}#design-system-bootstrap`,
+                name: "Design System Bootstrap & Governance",
                 description:
-                    "Strategy and implementation support for design systems.",
+                    "Tokens, components, and contribution rules that keep products consistent.",
                 provider: { "@id": `${base}#person` },
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
@@ -102,9 +109,10 @@ function buildStructuredData() {
             },
             {
                 "@type": "Service",
-                "@id": `${base}#accessibility-auditing`,
-                name: "Accessibility Auditing",
-                description: "WCAG reviews and inclusive design guidance.",
+                "@id": `${base}#frontend-platform-modernisation`,
+                name: "Frontend Platform & DX Modernisation",
+                description:
+                    "Build tooling, testing, and workflow improvements that lift delivery.",
                 provider: { "@id": `${base}#person` },
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
@@ -115,9 +123,10 @@ function buildStructuredData() {
             },
             {
                 "@type": "Service",
-                "@id": `${base}#frontend-engineering`,
-                name: "Frontend Engineering",
-                description: "Accessible and performant user interfaces.",
+                "@id": `${base}#full-stack-foundations`,
+                name: "Full-stack Foundations",
+                description:
+                    "API contracts, data models, auth, and CI/CD to support product delivery.",
                 provider: { "@id": `${base}#person` },
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {

--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -6,20 +6,20 @@ export default function Approach() {
         <Section id="approach" heading="My approach">
             <ol className={styles.steps}>
                 <li>
-                    <strong>Assess</strong> &rarr; deep-dive current UI,
-                    tooling, and workflows.
+                    <strong>Assess</strong> &rarr; review frontend, API
+                    boundaries, data flows, and CI.
                 </li>
                 <li>
                     <strong>Align</strong> &rarr; co-create a roadmap with
-                    design and product leads.
+                    design, product, and backend leads.
                 </li>
                 <li>
                     <strong>Execute</strong> &rarr; deliver tokens, components,
-                    and docs iteratively.
+                    API contracts, and docs iteratively.
                 </li>
                 <li>
-                    <strong>Govern</strong> &rarr; bake metrics and review loops
-                    into CI for sustained quality.
+                    <strong>Govern</strong> &rarr; bake metrics, tests, and
+                    review loops into CI for sustained quality.
                 </li>
             </ol>
         </Section>

--- a/components/CaseStudies/CaseStudies.tsx
+++ b/components/CaseStudies/CaseStudies.tsx
@@ -12,18 +12,33 @@ const caseStudies = [
         Visual: GlobalFintechVisual,
         before: "Fragmented widgets and 40% component duplication causing accessibility defects.",
         after: "Token-driven system adopted by 100% of teams; CI audits stopped regressions and cut UI bugs by a third.",
+        highlights: [
+            "Node/Express API with PostgreSQL and GraphQL gateway",
+            "Dockerised GitHub Actions to AWS ECS",
+            "JWT auth enforcing KYC/AML roles",
+        ],
     },
     {
         title: "B2C SaaS",
         Visual: B2CVisual,
         before: "Slow onboarding, inconsistent UI, hard-to-debug layouts.",
         after: "Bootstrap docs and codemods halved onboarding time and lifted release velocity 20%.",
+        highlights: [
+            "tRPC API with Prisma on PostgreSQL",
+            "Stripe payments with idempotent webhooks",
+            "GitLab CI with preview environments",
+        ],
     },
     {
         title: "Ecommerce",
         Visual: EcommerceVisual,
         before: "Flaky components, accessibility gaps, shipping delays.",
         after: "Refactored component library with automated a11y tests cut bug reports 60% and met WCAG AA.",
+        highlights: [
+            "REST API cached via Redis",
+            "WorldPay gateway with idempotent order handling",
+            "CDN and image optimisation cut LCP 40%",
+        ],
     },
 ];
 
@@ -35,19 +50,22 @@ export default function CaseStudies() {
             className={styles.caseStudies}
         >
             <p className={styles.tagline}>
-                Real-world outcomes from complex UI work.
+                Real-world outcomes across UI and platform work.
             </p>
 
             <div className={styles.cards}>
-                {caseStudies.map(({ title, Visual, before, after }) => (
-                    <CaseStudyCard
-                        key={title}
-                        title={title}
-                        visual={<Visual />}
-                        before={before}
-                        after={after}
-                    />
-                ))}
+                {caseStudies.map(
+                    ({ title, Visual, before, after, highlights }) => (
+                        <CaseStudyCard
+                            key={title}
+                            title={title}
+                            visual={<Visual />}
+                            before={before}
+                            after={after}
+                            highlights={highlights}
+                        />
+                    ),
+                )}
             </div>
             <div className={styles.cta}>
                 <p>Want these results for your team?</p>

--- a/components/CaseStudies/CaseStudyCard.module.scss
+++ b/components/CaseStudies/CaseStudyCard.module.scss
@@ -1,11 +1,7 @@
 @use "../../styles/mixins" as *;
 
 @layer components {
-    .steps {
-        @include steps;
-    }
-
-    .fullStack {
+    .highlights {
         margin-block-start: var(--space-m);
         padding-inline-start: var(--space-l);
         display: flex;

--- a/components/CaseStudies/CaseStudyCard.tsx
+++ b/components/CaseStudies/CaseStudyCard.tsx
@@ -1,11 +1,13 @@
 import { ReactNode } from "react";
 import Card from "@/components/Card/Card";
+import styles from "./CaseStudyCard.module.scss";
 
 interface CaseStudyCardProps {
     title: string;
     visual: ReactNode;
     before: string;
     after: string;
+    highlights?: string[];
 }
 
 export default function CaseStudyCard({
@@ -13,6 +15,7 @@ export default function CaseStudyCard({
     visual,
     before,
     after,
+    highlights = [],
 }: CaseStudyCardProps) {
     return (
         <Card title={title} size="md">
@@ -21,6 +24,16 @@ export default function CaseStudyCard({
             <p>{before}</p>
             <h4>After:</h4>
             <p>{after}</p>
+            {highlights.length > 0 && (
+                <>
+                    <h4>Backend & Platform highlights:</h4>
+                    <ul className={styles.highlights}>
+                        {highlights.map((item) => (
+                            <li key={item}>{item}</li>
+                        ))}
+                    </ul>
+                </>
+            )}
         </Card>
     );
 }

--- a/components/Contact/Contact.module.scss
+++ b/components/Contact/Contact.module.scss
@@ -15,4 +15,11 @@
     .ctaGroup {
         @include cta-group;
     }
+
+    .intro {
+        text-align: center;
+        max-inline-size: 40ch;
+        margin: var(--space-m) auto;
+        font-size: var(--step-0);
+    }
 }

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -6,8 +6,12 @@ export default function Contact() {
     return (
         <Section id="contact" labelledBy="contact-heading">
             <h2 id="contact-heading" className={styles.heading}>
-                Let&apos;s work together
+                Hire a frontend lead who goes full-stack
             </h2>
+            <p className={styles.intro}>
+                Available for principal roles, consulting, and architecture
+                engagements.
+            </p>
             <div className={styles.ctaGroup}>
                 <BookCallButton href="mailto:hello@lapidist.net">
                     Get in touch

--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -21,6 +21,13 @@
         font-size: var(--step-1);
     }
 
+    .fullStack {
+        @include centered-list(var(--space-xs), true);
+
+        margin-block-start: var(--space-s);
+        font-size: var(--step-negative-1);
+    }
+
     .ctaGroup {
         @include cta-group;
     }

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -12,19 +12,27 @@ export default function Hero() {
         >
             <div className={styles.ctaGroup}>
                 <h1 id="hero-heading" className={styles.heroTitle}>
-                    Principal Frontend Engineer. Crafting resilient design
-                    systems.
+                    Lead Frontend Engineer — full-stack capable when it
+                    multiplies outcomes.
                 </h1>
                 <p className={styles.heroIntro}>
-                    I help product teams ship systems that cut rework, lift
-                    accessibility, and accelerate delivery across distributed
-                    teams.
+                    I specialise in design systems and frontend platforms. When
+                    it matters, I architect APIs, model data, wire CI/CD, and
+                    integrate payments for regulated products.
                 </p>
+                <ul className={styles.fullStack}>
+                    <li>API design</li>
+                    <li>Data modelling</li>
+                    <li>Auth</li>
+                    <li>CI/CD</li>
+                    <li>Docker</li>
+                    <li>AWS</li>
+                </ul>
             </div>
             <div className={styles.ctaGroup}>
                 <div className={styles.cta}>
                     <BookCallButton size="lg">
-                        Discuss your frontend roadmap
+                        Discuss your platform roadmap
                     </BookCallButton>
                     <p className={styles.note}>Let&apos;s connect.</p>
                 </div>

--- a/components/Insights/Insights.module.scss
+++ b/components/Insights/Insights.module.scss
@@ -9,6 +9,12 @@
         @include centered-column;
     }
 
+    .tagline {
+        margin: 0;
+        text-align: center;
+        color: var(--text);
+    }
+
     .cards {
         @include card-grid();
     }

--- a/components/Insights/Insights.tsx
+++ b/components/Insights/Insights.tsx
@@ -17,6 +17,9 @@ export default function Insights({ articles }: { articles: Article[] }) {
             heading="Recent work & insights"
             className={styles.insights}
         >
+            <p className={styles.tagline}>
+                Articles on frontend platforms, API design, and design systems.
+            </p>
             <div className={styles.cards}>
                 {articles.map(({ year, slug, title, description }) => (
                     <Link key={`${year}-${slug}`} href={`/${year}/${slug}`}>

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -12,31 +12,30 @@ export default function Services() {
         <Section id="services" heading="Signature services">
             <div className={styles.cards}>
                 <Card
-                    title="Design System Bootstrap"
+                    title="Design System Bootstrap & Governance"
                     icon={<DesignSystemBootstrapIcon className={styles.icon} />}
                 >
                     <p>
-                        Launch a production-ready design system in weeks &ndash;
-                        boosting velocity, cutting rework, and improving
-                        accessibility from day one.
+                        Launch a production-ready system with tokens, components
+                        and contribution rules that keep products consistent.
                     </p>
                 </Card>
                 <Card
-                    title="System Audit & Roadmap"
+                    title="Frontend Platform & DX Modernisation"
                     icon={<SystemAuditRoadmapIcon className={styles.icon} />}
                 >
                     <p>
-                        Turn existing assets into a strategic UI architecture
-                        roadmap that reduces churn and flags risk early.
+                        Refine build tooling, testing, and workflows to cut
+                        defects and accelerate delivery.
                     </p>
                 </Card>
                 <Card
-                    title="Hands-on Build"
+                    title="Full-Stack Foundations"
                     icon={<HandsOnBuildIcon className={styles.icon} />}
                 >
                     <p>
-                        Ship resilient foundations without diverting your team
-                        so releases stay on schedule.
+                        Shape API contracts, data models, auth, and CI/CD so
+                        frontend work lands cleanly.
                     </p>
                 </Card>
                 <Card
@@ -44,8 +43,8 @@ export default function Services() {
                     icon={<ConsultingTeamUpliftIcon className={styles.icon} />}
                 >
                     <p>
-                        Raise team capability with ongoing mentorship that lifts
-                        quality and autonomy.
+                        Raise capability across the stack with mentoring that
+                        leaves teams self-sufficient.
                     </p>
                 </Card>
             </div>

--- a/components/TrustedBy/TrustedBy.tsx
+++ b/components/TrustedBy/TrustedBy.tsx
@@ -9,7 +9,8 @@ export default function TrustedBy() {
             className={styles.trustedBy}
         >
             <p className={styles.tagline}>
-                I help brands deliver reliable, inclusive products.
+                I help brands deliver reliable, inclusive, and scalable
+                products.
             </p>
             <ul className={styles.logos}>
                 <li>

--- a/components/WhatIBring/WhatIBring.tsx
+++ b/components/WhatIBring/WhatIBring.tsx
@@ -5,23 +5,36 @@ export default function WhatIBring() {
     return (
         <Section id="what-i-bring" heading="What I bring to the table">
             <p>
-                I bridge product, design, and engineering to steer UI strategy.
+                Specialist in frontend and design systems who steps across the
+                stack when it unlocks delivery.
             </p>
             <p>
-                My work spans scrappy MVPs to enterprise platforms adopted by
-                hundreds of engineers and many more users.
+                Experience ranges from MVPs to fintech platforms adopted by
+                hundreds of engineers and tens of thousands of users.
             </p>
             <p>
-                By pairing robust tooling with clear governance, I make sure
-                your UI systems scale without sacrificing quality.
+                I pair tooling with clear governance so UI and API contracts
+                evolve without regressions.
             </p>
             <ul className={styles.steps}>
                 <li>Grow cross-functional teams and mentoring culture.</li>
+                <li>Design API contracts that protect UI integrity.</li>
                 <li>Eliminate style drift with token-driven theming.</li>
-                <li>Cut PR churn by 40% through shared components.</li>
-                <li>Automate docs and handoff to speed delivery.</li>
-                <li>Embed accessibility and performance budgets.</li>
-                <li>Ship complex product surfaces in weeks, not months.</li>
+                <li>
+                    Cut PR churn 40% through shared components and typed utils.
+                </li>
+                <li>Automate docs, checks, and deployments via CI/CD.</li>
+                <li>Embed accessibility, performance, and error budgets.</li>
+            </ul>
+            <h3>Full-stack in practice</h3>
+            <ul className={styles.fullStack}>
+                <li>
+                    GraphQL schema with cursor pagination cut over-fetching 40%.
+                </li>
+                <li>Node/Express service with JWT auth and rate limits.</li>
+                <li>
+                    Dockerised CI on AWS trimmed deploy lead time to 10 min.
+                </li>
             </ul>
         </Section>
     );

--- a/content/articles/2025/design-systems-meet-api-contracts.mdx
+++ b/content/articles/2025/design-systems-meet-api-contracts.mdx
@@ -1,0 +1,12 @@
+---
+title: "Design Systems Meet API Contracts: Preventing Broken UIs at the Boundary"
+date: 2025-02-01
+description: "How shared contracts across UI and API cut integration bugs."
+draft: true
+---
+
+## Outline
+
+- Design tokens and API schemas drift.
+- Strategy: versioned GraphQL schema and typed components.
+- Result: stable interfaces and fewer regressions.

--- a/content/articles/2025/from-ui-to-slos.mdx
+++ b/content/articles/2025/from-ui-to-slos.mdx
@@ -1,0 +1,12 @@
+---
+title: "From UI to SLOs: What Frontend Leaders Should Instrument"
+date: 2025-02-10
+description: "Linking user experience metrics to backend SLOs."
+draft: true
+---
+
+## Outline
+
+- Map user flows to service-level objectives.
+- Instrument with OpenTelemetry and browser APIs.
+- Use budgets to guide investment.

--- a/content/articles/2025/on-freedom-curiosity-and-happiness.mdx
+++ b/content/articles/2025/on-freedom-curiosity-and-happiness.mdx
@@ -6,8 +6,10 @@ description: "Thoughts on exploring and enjoying life."
 
 ## Freedom
 
-Curiosity leads us to unexpected places.
+Curiosity leads us to unexpected places. In software it pulls me from
+colour tokens into API boundaries and data models.
 
 ## Happiness
 
-Happiness often follows curiosity and freedom.
+Happiness often follows curiosity and freedom—whether debugging a race
+condition or aligning a design system with backend contracts.

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { compileMDX } from "next-mdx-remote/rsc";
+import { notFound } from "next/navigation";
 
 const ARTICLES_PATH = path.join(process.cwd(), "content", "articles");
 
@@ -17,6 +18,9 @@ export async function getArticle(year: string, slug: string) {
     const filePath = path.join(ARTICLES_PATH, year, `${slug}.mdx`);
     const source = await fs.promises.readFile(filePath, "utf8");
     const { data, content } = matter(source);
+    if (data.draft) {
+        notFound();
+    }
     const { content: MDXContent } = await compileMDX({ source: content });
     const meta: ArticleMeta = {
         year,
@@ -40,6 +44,9 @@ export async function getAllArticles(): Promise<ArticleMeta[]> {
                 const filePath = path.join(dir, file);
                 const source = await fs.promises.readFile(filePath, "utf8");
                 const { data } = matter(source);
+                if (data.draft) {
+                    continue;
+                }
                 articles.push({
                     year,
                     slug,


### PR DESCRIPTION
## Summary
- emphasise full-stack capability in hero, approach, and about sections
- expand services and case studies with backend, ops, and fintech details
- add draft article outlines and filter draft posts from listings

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_689f320b05c883289b86145b480e79df