### PR TITLE
Ensure canonical URLs are absolute and match sitemap

### DIFF
--- a/app/[year]/[slug]/page.tsx
+++ b/app/[year]/[slug]/page.tsx
@@ -40,7 +40,8 @@ export async function generateMetadata({
 }): Promise<Metadata> {
     const { year, slug } = await params;
     const { meta } = await getArticle(year, slug);
-    const url = `/${year}/${slug}`;
+    const base = "https://lapidist.net";
+    const url = `${base}/${year}/${slug}/`;
     return {
         title: meta.title,
         description: meta.description,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,16 +6,16 @@ export const dynamic = "force-static";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const articles = await getAllArticles();
     const articleEntries = articles.map(({ year, slug, date }) => ({
-        url: `https://lapidist.net/${year}/${slug}`,
+        url: `https://lapidist.net/${year}/${slug}/`,
         lastModified: new Date(date),
     }));
     return [
         {
-            url: "https://lapidist.net",
+            url: "https://lapidist.net/",
             lastModified: new Date(),
         },
         {
-            url: "https://lapidist.net/articles",
+            url: "https://lapidist.net/articles/",
             lastModified: new Date(),
         },
         ...articleEntries,

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -52,6 +52,10 @@
         text-decoration: underline;
         text-decoration-thickness: 1px;
         text-underline-offset: 2px;
+
+        &:visited {
+            color: inherit;
+        }
     }
 
     section {

--- a/tests/sitemap.spec.ts
+++ b/tests/sitemap.spec.ts
@@ -1,10 +1,17 @@
 import { expect, test } from "@playwright/test";
 
-test("sitemap includes articles", async ({ request }) => {
-    const response = await request.get("/sitemap.xml");
-    expect(response.ok()).toBeTruthy();
-    const xml = await response.text();
-    expect(xml).toContain(
-        "https://lapidist.net/2025/on-freedom-curiosity-and-happiness",
-    );
+test("sitemap URLs match canonical URLs", async ({ request }) => {
+    const articlePath = "/2025/on-freedom-curiosity-and-happiness/";
+    const articleUrl = `https://lapidist.net${articlePath}`;
+
+    const sitemapResponse = await request.get("/sitemap.xml");
+    expect(sitemapResponse.ok()).toBeTruthy();
+    const xml = await sitemapResponse.text();
+    expect(xml).toContain(articleUrl);
+
+    const articleResponse = await request.get(articlePath);
+    expect(articleResponse.ok()).toBeTruthy();
+    const html = await articleResponse.text();
+    const canonicalMatch = html.match(/<link rel="canonical" href="([^"]+)"/);
+    expect(canonicalMatch?.[1]).toBe(articleUrl);
 });


### PR DESCRIPTION
## Summary
- generate absolute canonical URLs for articles and Open Graph metadata
- align sitemap entries and visited link styling with canonical URLs
- test canonical URLs against sitemap

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fbc8146c883288d3fa8a7646fcf61