### PR TITLE
feat: add hero badges and availability

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -38,6 +38,24 @@
         text-align: center;
     }
 
+    .availability {
+        font-size: var(--typography-size-100);
+        text-align: center;
+    }
+
+    .badges {
+        @include centered-list(var(--space-xs), true);
+
+        margin-block-start: var(--space-l);
+        font-size: var(--typography-size-100);
+
+        li {
+            background: var(--surface-level-1);
+            padding: var(--space-xxs) var(--space-xs);
+            border-radius: var(--radius-s);
+        }
+    }
+
     @container (min-width:50rem) {
         .heroTitle {
             font-size: var(--typography-size-600);

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -3,6 +3,15 @@ import Section from "@/components/Section/Section";
 import styles from "./Hero.module.scss";
 
 export default function Hero() {
+    const today = new Date();
+    const formattedDate = today.toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+    });
+    const isoDate = today.toISOString().split("T")[0];
+    const badges = ["20% faster releases", "WCAG AA compliance"];
+
     return (
         <Section
             className={styles.hero}
@@ -10,6 +19,10 @@ export default function Hero() {
             containerSize="l"
             contentVisibility={false}
         >
+            <p className={styles.availability}>
+                Currently open for roles/consulting –
+                <time dateTime={isoDate}> {formattedDate}</time>
+            </p>
             <div className={styles.ctaGroup}>
                 <h1 id="hero-heading" className={styles.heroTitle}>
                     Principal Frontend Engineer. Crafting resilient design
@@ -21,6 +34,13 @@ export default function Hero() {
                     teams.
                 </p>
             </div>
+            <ul className={styles.badges}>
+                {badges.map((badge) => (
+                    <li key={badge} className={styles.badge}>
+                        {badge}
+                    </li>
+                ))}
+            </ul>
             <div className={styles.ctaGroup}>
                 <div className={styles.cta}>
                     <BookCallButton size="lg">


### PR DESCRIPTION
## Summary
- showcase case study results with "20% faster releases" and "WCAG AA compliance" badges on the hero
- show current availability for roles/consulting with a dated stamp

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fcde1b5f08328a718d904ef9d6727