### PR TITLE
feat: add social share buttons

### DIFF
--- a/app/[year]/[slug]/page.tsx
+++ b/app/[year]/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
+import SocialShare from "@/components/SocialShare/SocialShare";
 import { getAllArticles, getArticle } from "@/lib/articles";
 import { buildArticleStructuredData } from "@/lib/structured-data";
 import styles from "./page.module.scss";
@@ -24,6 +25,8 @@ export default async function ArticlePage({
         slug,
         wordCount,
     );
+    const baseUrl = "https://lapidist.net";
+    const url = `${baseUrl}/${year}/${slug}/`;
     return (
         <>
             <script
@@ -38,6 +41,7 @@ export default async function ArticlePage({
                         <p className={styles.description}>{meta.description}</p>
                     )}
                     {content}
+                    <SocialShare url={url} title={meta.title} />
                 </article>
             </Section>
             <Contact />

--- a/components/SocialShare/SocialShare.tsx
+++ b/components/SocialShare/SocialShare.tsx
@@ -1,0 +1,42 @@
+import Button from "@/components/Button/Button";
+
+type Props = {
+    url: string;
+    title: string;
+};
+
+export default function SocialShare({ url, title }: Props) {
+    const encodedUrl = encodeURIComponent(url);
+    const encodedTitle = encodeURIComponent(title);
+
+    const links = [
+        {
+            href: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+            label: "Share on Twitter",
+        },
+        {
+            href: `https://www.linkedin.com/shareArticle?url=${encodedUrl}&title=${encodedTitle}`,
+            label: "Share on LinkedIn",
+        },
+        {
+            href: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+            label: "Share on Facebook",
+        },
+    ];
+
+    return (
+        <div>
+            {links.map(({ href, label }) => (
+                <Button
+                    key={label}
+                    href={href}
+                    variant="secondary"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    {label}
+                </Button>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add SocialShare component with accessible share links
- render SocialShare at the end of article content

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fcdce3b7c832896c0633c353eb391