### PR TITLE
feat: add pagination for articles

### DIFF
--- a/app/articles/page.module.scss
+++ b/app/articles/page.module.scss
@@ -7,3 +7,14 @@
     text-decoration: none;
     color: inherit;
 }
+
+.pagination {
+    display: flex;
+    justify-content: space-between;
+    margin-block-start: var(--space-xl);
+}
+
+.pagination a {
+    text-decoration: none;
+    color: inherit;
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -31,12 +31,14 @@ export const metadata: Metadata = {
 
 export default async function ArticlesPage() {
     const articles = await getAllArticles();
+    const pageArticles = articles.slice(0, 10);
+    const totalPages = Math.ceil(articles.length / 10);
     return (
         <>
             <Container as="section">
                 <h1>Articles</h1>
                 <div className={styles.cards}>
-                    {articles.map(({ year, slug, title, description }) => (
+                    {pageArticles.map(({ year, slug, title, description }) => (
                         <Link key={`${year}-${slug}`} href={`/${year}/${slug}`}>
                             <Card title={title} headingLevel="h2">
                                 <p>{description}</p>
@@ -44,6 +46,11 @@ export default async function ArticlesPage() {
                         </Link>
                     ))}
                 </div>
+                {totalPages > 1 && (
+                    <nav className={styles.pagination}>
+                        <Link href="/articles/page/2">Next</Link>
+                    </nav>
+                )}
             </Container>
             <Contact />
             <Footer />

--- a/app/articles/page/[page]/page.tsx
+++ b/app/articles/page/[page]/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Card from "@/components/Card/Card";
+import Contact from "@/components/Contact/Contact";
+import Container from "@/components/Container/Container";
+import Footer from "@/components/Footer/Footer";
+import { getAllArticles } from "@/lib/articles";
+import styles from "../../page.module.scss";
+
+const POSTS_PER_PAGE = 10;
+
+export async function generateStaticParams() {
+    const articles = await getAllArticles();
+    const totalPages = Math.ceil(articles.length / POSTS_PER_PAGE);
+    return Array.from({ length: totalPages }, (_, i) => ({
+        page: String(i + 1),
+    }));
+}
+
+export default async function ArticlesPage({
+    params,
+}: {
+    params: Promise<{ page: string }>;
+}) {
+    const { page } = await params;
+    const pageNumber = Number(page);
+    const articles = await getAllArticles();
+    const totalPages = Math.ceil(articles.length / POSTS_PER_PAGE);
+    const start = (pageNumber - 1) * POSTS_PER_PAGE;
+    const pageArticles = articles.slice(start, start + POSTS_PER_PAGE);
+    if (pageArticles.length === 0) {
+        notFound();
+    }
+    const prevPage = pageNumber - 1;
+    const nextPage = pageNumber + 1;
+    const prevHref =
+        prevPage === 1 ? "/articles" : `/articles/page/${String(prevPage)}`;
+    return (
+        <>
+            <Container as="section">
+                <h1>Articles</h1>
+                <div className={styles.cards}>
+                    {pageArticles.map(({ year, slug, title, description }) => (
+                        <Link key={`${year}-${slug}`} href={`/${year}/${slug}`}>
+                            <Card title={title} headingLevel="h2">
+                                <p>{description}</p>
+                            </Card>
+                        </Link>
+                    ))}
+                </div>
+                <nav className={styles.pagination}>
+                    {pageNumber > 1 && <Link href={prevHref}>Previous</Link>}
+                    {pageNumber < totalPages && (
+                        <Link href={`/articles/page/${String(nextPage)}`}>
+                            Next
+                        </Link>
+                    )}
+                </nav>
+            </Container>
+            <Contact />
+            <Footer />
+        </>
+    );
+}
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ page: string }>;
+}): Promise<Metadata> {
+    const { page } = await params;
+    const pageNumber = Number(page);
+    const title =
+        pageNumber > 1 ? `Articles - Page ${String(pageNumber)}` : "Articles";
+    const description =
+        "Articles and insights on front-end engineering and design systems.";
+    const url =
+        pageNumber > 1 ? `/articles/page/${String(pageNumber)}` : "/articles";
+    return {
+        title,
+        description,
+        alternates: { canonical: url },
+        openGraph: {
+            title,
+            description,
+            url,
+            type: "website",
+            images: [{ url: "/opengraph-image" }],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title,
+            description,
+            images: ["/twitter-image"],
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- paginate articles index and add navigation
- handle paginated routes via dynamic page component
- style pagination links with design tokens for spacing

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fcdce7ed08328b9c8a5694e911ea7