### PR TITLE
fix: improve footer contrast

### DIFF
--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -9,6 +9,7 @@
         font-size: var(--typography-size-100);
         text-align: center;
         color: var(--colour-text-subtle);
+        background: var(--surface-level-0);
     }
 
     .footerContainer {


### PR DESCRIPTION
## Summary
- ensure footer uses solid background for proper link contrast

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06d35ca0c8328baf829e4929911f8