### PR TITLE
Add metadata keywords and structured data for services

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,11 @@ const METADATA = {
     title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
     description:
         "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.",
+    keywords: [
+        "Principal Frontend Engineer",
+        "Design Systems Specialist",
+        "UK Remote",
+    ],
     theme: {
         light: "#ffffff",
         dark: "#090909",
@@ -55,6 +60,7 @@ export const metadata: Metadata = {
         template: `%s | ${METADATA.name}`,
     },
     description: METADATA.description,
+    keywords: [...METADATA.keywords],
     icons: { icon: METADATA.images.favicon },
     openGraph: {
         title: METADATA.title,

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -5,6 +5,13 @@ const PERSON = {
     "@id": `${BASE}#person`,
     name: "Brett Dorrans",
     url: `${BASE}/`,
+    jobTitle: "Principal Frontend Engineer",
+    image: `${BASE}/opengraph-image`,
+    contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "enquiries",
+        email: "hello@lapidist.net",
+    },
     address: {
         "@type": "PostalAddress",
         addressLocality: "Glasgow",
@@ -78,11 +85,11 @@ export function buildHomePageStructuredData(datePublished: string) {
                 ],
             },
             {
-                "@type": "Service",
-                "@id": `${BASE}#design-system-consulting`,
-                name: "Design System Consulting",
+                "@type": ["Service", "ProfessionalService"],
+                "@id": `${BASE}#design-system-bootstrap`,
+                name: "Design System Bootstrap",
                 description:
-                    "Strategy and implementation support for design systems.",
+                    "Launch a production-ready design system in weeks – boosting velocity, cutting rework, and improving accessibility from day one.",
                 provider: { "@id": `${BASE}#person` },
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
@@ -92,10 +99,11 @@ export function buildHomePageStructuredData(datePublished: string) {
                 },
             },
             {
-                "@type": "Service",
-                "@id": `${BASE}#accessibility-auditing`,
-                name: "Accessibility Auditing",
-                description: "WCAG reviews and inclusive design guidance.",
+                "@type": ["Service", "ProfessionalService"],
+                "@id": `${BASE}#system-audit-roadmap`,
+                name: "System Audit & Roadmap",
+                description:
+                    "Turn existing assets into a strategic UI architecture roadmap that reduces churn and flags risk early.",
                 provider: { "@id": `${BASE}#person` },
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
@@ -105,10 +113,25 @@ export function buildHomePageStructuredData(datePublished: string) {
                 },
             },
             {
-                "@type": "Service",
-                "@id": `${BASE}#frontend-engineering`,
-                name: "Frontend Engineering",
-                description: "Accessible and performant user interfaces.",
+                "@type": ["Service", "ProfessionalService"],
+                "@id": `${BASE}#hands-on-build`,
+                name: "Hands-on Build",
+                description:
+                    "Ship resilient foundations without diverting your team so releases stay on schedule.",
+                provider: { "@id": `${BASE}#person` },
+                areaServed: ["United Kingdom", "Remote"],
+                offers: {
+                    "@type": "AggregateOffer",
+                    priceCurrency: "GBP",
+                    priceRange: "£££",
+                },
+            },
+            {
+                "@type": ["Service", "ProfessionalService"],
+                "@id": `${BASE}#consulting-team-uplift`,
+                name: "Consulting & Team Uplift",
+                description:
+                    "Raise team capability with ongoing mentorship that lifts quality and autonomy.",
                 provider: { "@id": `${BASE}#person` },
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {


### PR DESCRIPTION
## Summary
- include targeted SEO keywords in global metadata
- enrich Person schema with job title, image, and contact point
- expose Service/ProfessionalService schemas for signature offerings

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08146f9c08328b5631e59a43fcd7e