### PR TITLE
feat: enhance blog metadata and layout

### DIFF
--- a/app/articles/[year]/[slug]/page.tsx
+++ b/app/articles/[year]/[slug]/page.tsx
@@ -74,13 +74,14 @@ export async function generateMetadata({
             url,
             type: "article",
             publishedTime: meta.date,
-            images: [{ url: "/opengraph-image" }],
+            images: meta.image ? [{ url: meta.image }] : undefined,
+            authors: meta.author.url ? [meta.author.url] : undefined,
         },
         twitter: {
             card: "summary_large_image",
             title: meta.title,
             description: meta.description,
-            images: ["/twitter-image"],
+            images: meta.image ? [meta.image] : undefined,
         },
     };
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
         url: "/articles",
         type: "website",
         images: [{ url: "/opengraph-image" }],
+        siteName: "Lapidist",
     },
     twitter: {
         card: "summary_large_image",
@@ -36,13 +37,13 @@ export default async function ArticlesPage() {
             <Container as="section">
                 <h1>Articles</h1>
                 <div className={styles.cards}>
-                    {articles.map(({ year, slug, title, description }) => (
+                    {articles.map(({ year, slug, title, summary }) => (
                         <Link
                             key={`${year}-${slug}`}
                             href={`/articles/${year}/${slug}`}
                         >
                             <Card title={title} headingLevel="h2">
-                                <p>{description}</p>
+                                <p>{summary}</p>
                             </Card>
                         </Link>
                     ))}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -115,6 +115,11 @@ export default function RootLayout({
                 />
                 <link rel="preload" as="image" href={METADATA.images.og} />
                 <link
+                    rel="alternate"
+                    type="application/rss+xml"
+                    href="/rss.xml"
+                />
+                <link
                     rel="mask-icon"
                     href={METADATA.images.mask}
                     color="#6847ff"

--- a/content/articles/2025/on-freedom-curiosity-and-happiness.mdx
+++ b/content/articles/2025/on-freedom-curiosity-and-happiness.mdx
@@ -3,6 +3,10 @@ title: "On freedom, curiosity, and happiness"
 date: 2025-01-01
 description: "Thoughts on exploring and enjoying life."
 summary: "Exploring how curiosity and freedom shape happiness."
+image: "/opengraph-image"
+author:
+    name: "Brett Dorrans"
+    url: "https://lapidist.net"
 tags:
     - personal
     - philosophy

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -16,6 +16,11 @@ export interface ArticleMeta {
     tags: string[];
     date: string;
     readingTime: string;
+    image: string;
+    author: {
+        name?: string;
+        url?: string;
+    };
 }
 
 export async function getArticle(year: string, slug: string) {
@@ -39,6 +44,8 @@ export async function getArticle(year: string, slug: string) {
         tags: (data.tags as string[] | undefined) ?? [],
         date: data.date as string,
         readingTime: readingTimeText,
+        image: (data.image as string) || "",
+        author: ((data.author ?? {}) as { name?: string; url?: string }),
     };
     return { meta, content: MDXContent, wordCount };
 }
@@ -71,6 +78,11 @@ export async function getAllArticles(): Promise<ArticleMeta[]> {
                     tags: (data.tags as string[] | undefined) ?? [],
                     date: data.date as string,
                     readingTime: readingTimeText,
+                    image: (data.image as string) || "",
+                    author: ((data.author ?? {}) as {
+                        name?: string;
+                        url?: string;
+                    }),
                 });
             }
         }


### PR DESCRIPTION
## Summary
- ensure articles include image and author URL metadata
- add RSS feed link to layout head
- show article summaries on listing and expose share metadata

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a081ba66bc83288954514b5643e287