### PR TITLE
Add accessibility statement page and improve navigation

### DIFF
--- a/app/accessibility-statement/page.tsx
+++ b/app/accessibility-statement/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import Contact from "@/components/Contact/Contact";
+import Container from "@/components/Container/Container";
+import Footer from "@/components/Footer/Footer";
+
+export const metadata: Metadata = {
+    title: "Accessibility Statement",
+    description: "Commitment to an accessible web experience.",
+    alternates: { canonical: "/accessibility-statement" },
+};
+
+export default function AccessibilityStatementPage() {
+    return (
+        <>
+            <Container as="section">
+                <h1>Accessibility Statement</h1>
+                <p>
+                    I strive to make this website accessible to everyone. If you
+                    encounter any accessibility barriers or have suggestions,
+                    please get in touch so I can improve the experience.
+                </p>
+            </Container>
+            <Contact />
+            <Footer />
+        </>
+    );
+}

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -17,6 +17,11 @@ export default function Footer() {
                         <li>
                             <a href="#contact">Contact</a>
                         </li>
+                        <li>
+                            <Link href="/accessibility-statement">
+                                Accessibility Statement
+                            </Link>
+                        </li>
                     </ul>
                 </nav>
                 <ul className={styles.social}>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,24 +1,32 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import Container from "@/components/Container/Container";
 import ThemeToggle from "@/components/ThemeToggle/ThemeToggle";
 import styles from "./Header.module.scss";
 import LogoMark from "./LogoMark";
 
 export default function Header() {
+    const pathname = usePathname();
+
     return (
         <header className={styles.header}>
             <Container className={styles.inner} as="div" cq="page">
-                <Link
-                    href="/"
-                    className={styles.logo}
-                    aria-label="Brett Dorrans"
-                >
-                    <LogoMark />
-                    <span className={styles.logoLockup}>
-                        <span>Brett</span>
-                        <span>Dorrans</span>
-                    </span>
-                </Link>
+                <nav role="navigation">
+                    <Link
+                        href="/"
+                        className={styles.logo}
+                        aria-label="Brett Dorrans"
+                        aria-current={pathname === "/" ? "page" : undefined}
+                    >
+                        <LogoMark />
+                        <span className={styles.logoLockup}>
+                            <span>Brett</span>
+                            <span>Dorrans</span>
+                        </span>
+                    </Link>
+                </nav>
                 <ThemeToggle />
             </Container>
         </header>


### PR DESCRIPTION
## Summary
- highlight active navigation link with `aria-current` and `<nav role="navigation">`
- add an Accessibility Statement page
- link the new page from the footer

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08170c3548328bf9abac4dc05e25e