### PR TITLE
chore: remove unused structured data exports

### DIFF
--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -45,7 +45,7 @@ export async function getArticle(year: string, slug: string) {
         date: data.date as string,
         readingTime: readingTimeText,
         image: (data.image as string) || "",
-        author: ((data.author ?? {}) as { name?: string; url?: string }),
+        author: (data.author ?? {}) as { name?: string; url?: string },
     };
     return { meta, content: MDXContent, wordCount };
 }
@@ -79,10 +79,10 @@ export async function getAllArticles(): Promise<ArticleMeta[]> {
                     date: data.date as string,
                     readingTime: readingTimeText,
                     image: (data.image as string) || "",
-                    author: ((data.author ?? {}) as {
+                    author: (data.author ?? {}) as {
                         name?: string;
                         url?: string;
-                    }),
+                    },
                 });
             }
         }

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -197,5 +197,3 @@ export function buildArticleStructuredData(
         ],
     } as const;
 }
-
-export { BASE as baseUrl, PERSON as person, ORGANIZATION as organization };


### PR DESCRIPTION
## Summary
- remove unused exports from structured data helpers
- format articles helper to satisfy Prettier

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0beb79db48328ade6f9b32baff91c