### PR TITLE
Animate TrustedBy logos on hover

### DIFF
--- a/components/TrustedBy/TrustedBy.module.scss
+++ b/components/TrustedBy/TrustedBy.module.scss
@@ -28,4 +28,22 @@
         width: 12ch;
         height: 5ch;
     }
+
+    @media (hover: hover) and (pointer: fine) {
+        .logo {
+            transition: transform var(--motion-dur-200)
+                var(--motion-ease-standard);
+        }
+
+        .logoLink:hover .logo {
+            transform: scale(1.05);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .logo {
+            transition: none;
+            transform: none;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add hover scale animation to logos in the TrustedBy section using motion tokens
- disable animation for users with reduced motion preferences

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c60a14ac8328be35d494b3b13b1f