### PR TITLE
feat: add subtle button hover animation

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -56,21 +56,23 @@
                 transform var(--motion-dur-120) var(--motion-ease-emphasized);
         }
 
+        .button:not(:disabled):hover {
+            box-shadow: var(--shadow-elev-2);
+            transform: translateY(-1px);
+        }
+
         .button:not(:disabled)[data-variant="primary"]:hover {
             background: var(--colour-primary-hover);
-            box-shadow: var(--shadow-elev-2);
             color: var(--colour-on-primary);
         }
 
         .button:not(:disabled)[data-variant="secondary"]:hover {
             background: var(--colour-primary-hover);
-            box-shadow: var(--shadow-elev-2);
             color: var(--colour-on-primary);
         }
 
         .button:not(:disabled)[data-variant="ghost"]:hover {
             background: var(--surface-level-1-hover);
-            box-shadow: var(--shadow-elev-2);
             color: var(--colour-on-primary);
         }
 
@@ -95,6 +97,10 @@
     @media (prefers-reduced-motion: reduce) {
         .button {
             transition: none;
+            transform: none;
+        }
+
+        .button:not(:disabled):hover {
             transform: none;
         }
     }


### PR DESCRIPTION
## Summary
- add a translateY transform for button hover using existing motion tokens
- disable hover transform when `prefers-reduced-motion: reduce` is set

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5efc5d483289f98025d15db70ae