### PR TITLE
refactor: remove ghost and loading button variants

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -34,18 +34,9 @@
         border-color: var(--colour-primary);
     }
 
-    .button[data-variant="ghost"] {
-        background: transparent;
-        color: var(--colour-text);
-    }
-
     .button:disabled {
         cursor: not-allowed;
         opacity: 0.6;
-    }
-
-    .button[aria-busy="true"] {
-        cursor: wait;
     }
 
     @media (hover: hover) and (pointer: fine) {
@@ -68,22 +59,12 @@
             color: var(--colour-on-primary);
         }
 
-        .button:not(:disabled)[data-variant="ghost"]:hover {
-            background: var(--surface-level-1-hover);
-            box-shadow: var(--shadow-elev-2);
-            color: var(--colour-on-primary);
-        }
-
         .button:not(:disabled)[data-variant="primary"]:active {
             background: var(--colour-primary-active);
         }
 
         .button:not(:disabled)[data-variant="secondary"]:active {
             background: var(--colour-primary-active);
-        }
-
-        .button:not(:disabled)[data-variant="ghost"]:active {
-            background: var(--surface-level-1-active);
         }
 
         .button:not(:disabled):active {

--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -19,44 +19,12 @@ export const Secondary: Story = {
     args: { variant: "secondary" },
 };
 
-export const Ghost: Story = {
-    args: { variant: "ghost" },
-};
-
 export const Large: Story = {
     args: { size: "lg" },
 };
 
-export const LargeLoading: Story = {
-    args: { size: "lg", loading: true },
-};
-
-export const Loading: Story = {
-    args: { loading: true },
-};
-
 export const SecondaryLarge: Story = {
     args: { variant: "secondary", size: "lg" },
-};
-
-export const SecondaryLoading: Story = {
-    args: { variant: "secondary", loading: true },
-};
-
-export const SecondaryLargeLoading: Story = {
-    args: { variant: "secondary", size: "lg", loading: true },
-};
-
-export const GhostLarge: Story = {
-    args: { variant: "ghost", size: "lg" },
-};
-
-export const GhostLoading: Story = {
-    args: { variant: "ghost", loading: true },
-};
-
-export const GhostLargeLoading: Story = {
-    args: { variant: "ghost", size: "lg", loading: true },
 };
 
 export const AsLink: Story = {

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -9,9 +9,8 @@ import clsx from "clsx";
 import styles from "./Button.module.scss";
 
 type BaseProps = {
-    variant?: "primary" | "secondary" | "ghost";
+    variant?: "primary" | "secondary";
     size?: "md" | "lg";
-    loading?: boolean;
     className?: string;
     children: ReactNode;
 };
@@ -30,7 +29,6 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
         {
             variant = "primary",
             size = "md",
-            loading = false,
             className,
             children,
             href,
@@ -42,7 +40,6 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
         const data = {
             "data-variant": variant,
             "data-size": size,
-            "data-loading": loading,
         } as const;
 
         if (href) {
@@ -52,7 +49,6 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
                     {...data}
                     href={href}
                     className={classes}
-                    aria-busy={loading || undefined}
                     ref={ref as Ref<HTMLAnchorElement>}
                 >
                     {children}
@@ -68,8 +64,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
                 type={buttonRest.type ?? "button"}
                 {...data}
                 className={classes}
-                aria-busy={loading || undefined}
-                disabled={loading || buttonRest.disabled}
+                disabled={buttonRest.disabled}
                 ref={ref as Ref<HTMLButtonElement>}
             >
                 {children}


### PR DESCRIPTION
## Summary
- drop ghost and loading styles from Button module
- simplify Button component props and remove loading state
- clean up Storybook stories to match available variants

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5b93544832886ccf274e60dd404