### PR TITLE
Wrap case studies in cards

### DIFF
--- a/components/CaseStudies/CaseStudies.module.scss
+++ b/components/CaseStudies/CaseStudies.module.scss
@@ -2,7 +2,6 @@
 
 @layer components {
     .caseStudies {
-        background: var(--surface-level-1);
         text-align: center;
     }
 
@@ -28,15 +27,9 @@
 
     .item {
         display: flex;
+        flex-direction: row;
         gap: var(--space-l);
         align-items: flex-start;
-        padding-block: var(--space-xl);
-        border-block-start: 1px solid var(--colour-border);
-    }
-
-    .item:first-child {
-        border-block-start: none;
-        padding-block-start: 0;
     }
 
     .media {
@@ -58,11 +51,6 @@
         flex-direction: column;
         gap: var(--space-s);
         max-width: var(--typography-measure);
-    }
-
-    .content h3 {
-        margin: 0 0 var(--space-s);
-        font-size: var(--typography-size-300);
     }
 
     .content p {

--- a/components/CaseStudies/CaseStudies.tsx
+++ b/components/CaseStudies/CaseStudies.tsx
@@ -1,4 +1,5 @@
 import Button from "@/components/Button/Button";
+import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import B2CVisual from "./B2CVisual";
 import styles from "./CaseStudies.module.scss";
@@ -62,12 +63,16 @@ export default function CaseStudies() {
                         solution,
                         impact,
                     }) => (
-                        <li key={title} className={styles.item}>
+                        <Card
+                            as="li"
+                            key={title}
+                            title={title}
+                            className={styles.item}
+                        >
                             <div className={styles.media}>
                                 <Visual />
                             </div>
                             <div className={styles.content}>
-                                <h3>{title}</h3>
                                 <p>
                                     <strong>Business context:</strong> {context}
                                 </p>
@@ -84,7 +89,7 @@ export default function CaseStudies() {
                                     <strong>Impact:</strong> {impact}
                                 </p>
                             </div>
-                        </li>
+                        </Card>
                     ),
                 )}
             </ul>


### PR DESCRIPTION
## Summary
- Remove section background in Case Studies
- Render each case study using the Card component

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc90cfec8328bb244cfa37dcc5e8