### PR TITLE
Refine case study visual spacing

### DIFF
--- a/components/CaseStudies/CaseStudies.module.scss
+++ b/components/CaseStudies/CaseStudies.module.scss
@@ -33,7 +33,7 @@
     }
 
     .media {
-        flex: 0 0 12rem;
+        flex: 0 0 calc(var(--space-3xl) * 2);
     }
 
     .visual {
@@ -49,7 +49,7 @@
         flex: 1;
         display: flex;
         flex-direction: column;
-        gap: var(--space-s);
+        gap: var(--space-m);
         max-width: var(--typography-measure);
     }
 


### PR DESCRIPTION
## Summary
- shrink case study visual width using design tokens so illustrations are less dominant
- increase content spacing for more readable case study text

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d0d0c75c8328a20c6192eb84bf66