### PR TITLE
Polish interactive component design

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -39,6 +39,10 @@
         opacity: 0.6;
     }
 
+    .button:not(:disabled):focus-visible {
+        box-shadow: var(--shadow-elev-2);
+    }
+
     @media (hover: hover) and (pointer: fine) {
         .button:not(:disabled) {
             transition:

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -9,6 +9,7 @@
         gap: var(--space-m);
         color: var(--colour-text);
         transition:
+            background var(--motion-dur-200) var(--motion-ease-standard),
             box-shadow var(--motion-dur-200) var(--motion-ease-standard),
             transform var(--motion-dur-120) var(--motion-ease-emphasized);
     }
@@ -23,17 +24,20 @@
 
     .card:focus-within {
         box-shadow: var(--shadow-elev-2);
+        background: var(--surface-level-1-hover);
     }
 
     @media (hover: hover) and (pointer: fine) {
         .card:hover {
             box-shadow: var(--shadow-elev-2);
             transform: translateY(-1px);
+            background: var(--surface-level-1-hover);
         }
 
         .card:active {
             box-shadow: var(--shadow-elev-3);
             transform: translateY(1px);
+            background: var(--surface-level-1-active);
         }
     }
 

--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -47,6 +47,14 @@
             box-shadow var(--motion-dur-200) var(--motion-ease-standard);
     }
 
+    .footerNav a:focus-visible,
+    .social a:focus-visible {
+        background: var(--surface-level-1-hover);
+        color: var(--colour-primary);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-elev-2);
+    }
+
     @media (hover: hover) and (pointer: fine) {
         .footerNav a:hover,
         .social a:hover {


### PR DESCRIPTION
## Summary
- add background transitions and hover/active polish to cards
- enhance footer link focus styles for keyboard users
- elevate buttons on focus for clearer interaction

## Testing
- `npm run test:install-browsers`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f25e1a308328883a8d6fa66b4174