### PR TITLE
feat: refine design details

### DIFF
--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -1,6 +1,16 @@
 @layer components {
     .header {
+        position: sticky;
+        inset-block-start: 0;
+        background: color-mix(in srgb, var(--surface-level-0) 90%, transparent);
+        backdrop-filter: blur(8px);
         border-block-end: 1px solid var(--colour-border);
+        z-index: var(--z-2);
+        transition: box-shadow var(--motion-dur-200) var(--motion-ease-standard);
+    }
+
+    .header[data-scrolled] {
+        box-shadow: var(--shadow-elev-1);
     }
 
     .inner {

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Container from "@/components/Container/Container";
@@ -9,9 +10,22 @@ import LogoMark from "./LogoMark";
 
 export default function Header() {
     const pathname = usePathname();
+    const [scrolled, setScrolled] = useState(false);
+
+    useEffect(() => {
+        function onScroll() {
+            setScrolled(window.scrollY > 0);
+        }
+
+        onScroll();
+        window.addEventListener("scroll", onScroll);
+        return () => {
+            window.removeEventListener("scroll", onScroll);
+        };
+    }, []);
 
     return (
-        <header className={styles.header}>
+        <header className={styles.header} data-scrolled={scrolled || undefined}>
             <Container className={styles.inner} as="div" cq="page">
                 <nav role="navigation">
                     <Link

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -54,28 +54,49 @@
 
     a:not([class]) {
         color: var(--colour-primary);
-        text-decoration: underline;
-        text-decoration-thickness: 1px;
-        text-underline-offset: 2px;
-        text-decoration-color: currentcolor;
-        transition:
-            color var(--motion-dur-200) var(--motion-ease-standard),
-            text-decoration-color var(--motion-dur-200)
-                var(--motion-ease-standard);
+        position: relative;
+        text-decoration: none;
+        transition: color var(--motion-dur-200) var(--motion-ease-standard);
 
         &:visited {
             color: var(--colour-primary);
         }
 
+        &::before {
+            content: "";
+            position: absolute;
+            inset-inline: 0;
+            inset-block-end: 0;
+            block-size: 1px;
+            background: currentcolor;
+            transform: scaleX(0);
+            transform-origin: left;
+            transition: transform var(--motion-dur-200)
+                var(--motion-ease-standard);
+        }
+
+        &:focus-visible::before {
+            transform: scaleX(1);
+        }
+
         @media (hover: hover) and (pointer: fine) {
             &:hover {
                 color: var(--colour-primary-hover);
-                text-decoration-color: var(--colour-primary-hover);
             }
 
             &:active {
                 color: var(--colour-primary-active);
-                text-decoration-color: var(--colour-primary-active);
+            }
+
+            &:hover::before,
+            &:active::before {
+                transform: scaleX(1);
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            &::before {
+                transition: none;
             }
         }
     }


### PR DESCRIPTION
## Summary
- animate default link underlines for a sleeker hover experience
- make header sticky with blurred background and scroll shadow

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f56c908c8328bdf49481761c0baa