### PR TITLE
Polish micro-interactions across UI

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -15,6 +15,7 @@
         border-radius: var(--radius-m);
         min-block-size: var(--size-tap-min);
         box-shadow: var(--shadow-elev-1);
+        will-change: box-shadow, transform, background;
     }
 
     .button[data-size="lg"] {

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -8,6 +8,7 @@
         flex-direction: column;
         gap: var(--space-m);
         color: var(--colour-text);
+        will-change: box-shadow, transform, background;
         transition:
             background var(--motion-dur-200) var(--motion-ease-standard),
             box-shadow var(--motion-dur-200) var(--motion-ease-standard),

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -6,7 +6,10 @@
         backdrop-filter: blur(8px);
         border-block-end: 1px solid var(--colour-border);
         z-index: var(--z-2);
-        transition: box-shadow var(--motion-dur-200) var(--motion-ease-standard);
+        transition:
+            background var(--motion-dur-200) var(--motion-ease-standard),
+            box-shadow var(--motion-dur-200) var(--motion-ease-standard);
+        will-change: background, box-shadow;
     }
 
     .inner {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -111,6 +111,8 @@
     :focus-visible {
         outline: var(--border-focus-ring);
         outline-offset: var(--space-focus-ring-offset);
+        transition: outline-offset var(--motion-dur-200)
+            var(--motion-ease-standard);
     }
 
     ::selection {


### PR DESCRIPTION
## Summary
- Animate sticky header background for smoother scroll transitions
- Add will-change hints to card and button components for polished motion
- Soften focus ring changes with a dedicated outline-offset transition

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10a4b1330832884103f83590ea812