### PR TITLE
Polish global styles for a modern look

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -22,6 +22,7 @@
         scroll-behavior: smooth;
         scrollbar-width: thin;
         scrollbar-color: var(--colour-primary) var(--surface-level-1);
+        accent-color: var(--colour-primary);
     }
 
     body {
@@ -55,6 +56,10 @@
         font-variation-settings:
             "opsz" var(--typography-font-opsz),
             "slnt" var(--typography-font-slnt);
+    }
+
+    :where(h1, h2, h3, h4, h5, h6)[id] {
+        scroll-margin-block-start: var(--space-2xl);
     }
 
     a:not([class]) {

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -8,6 +8,7 @@
     margin-block: 0;
     line-height: var(--typography-line-normal);
     max-inline-size: var(--typography-measure);
+    text-wrap: pretty;
 }
 
 :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl)


### PR DESCRIPTION
## Summary
- add `accent-color` to match form controls with brand color
- prevent anchor jumps from hiding behind sticky header
- improve paragraph and list wrapping with `text-wrap: pretty`

## Testing
- `npm run format:write`
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a11995af488328a9dbe713f66cdd3b