### PR TITLE
Fix hero opacity animation

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -1,5 +1,17 @@
 @use "../../styles/mixins" as *;
 
+@keyframes fade-in-up {
+    from {
+        opacity: 0;
+        transform: translateY(var(--space-m));
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 @layer components {
     .hero {
         position: relative;
@@ -82,18 +94,6 @@
 
         .cta:nth-of-type(2) {
             animation-delay: 0.8s;
-        }
-    }
-
-    @keyframes fade-in-up {
-        from {
-            opacity: 0;
-            transform: translateY(var(--space-m));
-        }
-
-        to {
-            opacity: 1;
-            transform: translateY(0);
         }
     }
 


### PR DESCRIPTION
## Summary
- define fade-in-up keyframes outside of component layer to ensure hero content fades in

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1269c1de48328823b5a953527446f