### PR TITLE
feat(header): make header background transparent until scroll

### DIFF
--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -2,9 +2,8 @@
     .header {
         position: sticky;
         inset-block-start: 0;
-        background: color-mix(in srgb, var(--surface-level-0) 90%, transparent);
-        backdrop-filter: blur(8px);
-        border-block-end: 1px solid var(--colour-border);
+        background: transparent;
+        border-block-end: 1px solid transparent;
         z-index: var(--z-2);
         transition:
             background var(--motion-dur-200) var(--motion-ease-standard),
@@ -21,6 +20,9 @@
     }
 
     .header[data-scrolled] {
+        background: color-mix(in srgb, var(--surface-level-0) 90%, transparent);
+        backdrop-filter: blur(8px);
+        border-block-end-color: var(--colour-border);
         box-shadow: var(--shadow-elev-1);
     }
 


### PR DESCRIPTION
## Summary
- make header transparent by default, adding background/blur once scrolled

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a126aca2e8832892ec8b1e6c3f3d96