### PR TITLE
Reduce case study visual dominance

### DIFF
--- a/components/CaseStudies/CaseStudies.module.scss
+++ b/components/CaseStudies/CaseStudies.module.scss
@@ -33,7 +33,7 @@
     }
 
     .media {
-        flex: 0 0 calc(var(--space-3xl) * 2);
+        flex: 0 0 calc(var(--space-3xl) * 1.5);
     }
 
     .visual {
@@ -84,7 +84,8 @@
 
         .media {
             flex-basis: auto;
-            width: 100%;
+            width: min(100%, calc(var(--space-3xl) * 4));
+            margin-inline: auto;
         }
     }
 }


### PR DESCRIPTION
## Summary
- shrink case study visuals to keep them from overpowering text
- cap visual width on narrow screens and center the images

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers` *(fails: apt-get install prolonged; process killed)*
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a12976c108832886da8668bab743fc