### PR TITLE
refactor: streamline contact section heading

### DIFF
--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -4,10 +4,11 @@ import styles from "./Contact.module.scss";
 
 export default function Contact() {
     return (
-        <Section id="contact" labelledBy="contact-heading">
-            <h2 id="contact-heading" className={styles.heading}>
-                Let&apos;s work together
-            </h2>
+        <Section
+            id="contact"
+            heading="Let's work together"
+            headingClassName={styles.heading}
+        >
             <div className={styles.ctaGroup}>
                 <Button href="mailto:hello@lapidist.net">Get in touch</Button>
                 <Button href="/brett-dorrans-cv.pdf" variant="secondary">


### PR DESCRIPTION
## Summary
- use built-in Section heading props in Contact for consistent markup

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a129e28ef48328b5dfbd7bb9567836