### PR TITLE
fix: align hero animation with motion tokens

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -72,7 +72,7 @@
         .cta {
             opacity: 0;
             transform: translateY(var(--space-m));
-            animation: fade-in-up var(--motion-dur-400)
+            animation: fade-in-up var(--motion-dur-320)
                 var(--motion-ease-emphasized) forwards;
         }
 


### PR DESCRIPTION
## Summary
- fix hero animation duration to use defined motion token

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a129f5f74083289b379e60ce94b58f