### PR TITLE
refactor: simplify link hover underline

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -9,6 +9,7 @@
     to {
         opacity: 1;
         transform: translateY(0);
+        visibility: visible;
     }
 }
 
@@ -72,6 +73,7 @@
         .cta {
             opacity: 0;
             transform: translateY(var(--space-m));
+            visibility: hidden;
             animation: fade-in-up var(--motion-dur-320)
                 var(--motion-ease-emphasized) forwards;
         }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -64,50 +64,37 @@
 
     a:not([class]) {
         color: var(--colour-primary);
-        position: relative;
-        text-decoration: none;
-        transition: color var(--motion-dur-200) var(--motion-ease-standard);
+        text-decoration-line: underline;
+        text-decoration-color: transparent;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 0.2em;
+        transition:
+            color var(--motion-dur-200) var(--motion-ease-standard),
+            text-decoration-color var(--motion-dur-200)
+                var(--motion-ease-standard);
 
         &:visited {
             color: var(--colour-primary);
         }
 
-        &::before {
-            content: "";
-            position: absolute;
-            inset-inline: 0;
-            inset-block-end: 0;
-            block-size: 1px;
-            background: currentcolor;
-            transform: scaleX(0);
-            transform-origin: left;
-            transition: transform var(--motion-dur-200)
-                var(--motion-ease-standard);
-        }
-
-        &:focus-visible::before {
-            transform: scaleX(1);
+        &:focus-visible {
+            text-decoration-color: currentcolor;
         }
 
         @media (hover: hover) and (pointer: fine) {
             &:hover {
                 color: var(--colour-primary-hover);
+                text-decoration-color: currentcolor;
             }
 
             &:active {
                 color: var(--colour-primary-active);
-            }
-
-            &:hover::before,
-            &:active::before {
-                transform: scaleX(1);
+                text-decoration-color: currentcolor;
             }
         }
 
         @media (prefers-reduced-motion: reduce) {
-            &::before {
-                transition: none;
-            }
+            transition: none;
         }
     }
 


### PR DESCRIPTION
## Summary
- simplify link hover effect to a subtle underline fade instead of animated line
- hide hero CTA while it fades in so invisible links don't trigger color-contrast violations

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a4be77f08328b666fec0a72a4114