### PR TITLE
feat: style article blockquotes

### DIFF
--- a/app/articles/[year]/[slug]/page.module.scss
+++ b/app/articles/[year]/[slug]/page.module.scss
@@ -14,6 +14,19 @@
         font-size: var(--typography-size-300);
     }
 
+    .article :global(blockquote) {
+        margin: 0;
+        padding: var(--space-m) var(--space-l);
+        border-inline-start: 4px solid var(--colour-primary);
+        background: var(--surface-level-1);
+        border-radius: var(--radius-m);
+        font-style: italic;
+    }
+
+    .article :global(blockquote p) {
+        margin: 0;
+    }
+
     .article :global(.footnotes) {
         border-top: 1px solid var(--colour-border);
         font-size: var(--typography-size-300);

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -4,15 +4,15 @@
     max-inline-size: var(--typography-measure);
 }
 
-:where(p, ul, ol, dl) {
+:where(p, ul, ol, dl, blockquote) {
     margin-block: 0;
     line-height: var(--typography-line-normal);
     max-inline-size: var(--typography-measure);
     text-wrap: pretty;
 }
 
-:where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl)
-    + :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl) {
+:where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote)
+    + :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote) {
     margin-block-start: var(--space-l);
 }
 


### PR DESCRIPTION
## Summary
- style article blockquotes with primary border and subtle background
- include blockquotes in global typography spacing rules

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b15f5bec83289623e6160118e2f6