### PR TITLE
feat: add AI ethics statement page

### DIFF
--- a/app/ai-ethics-statement/page.tsx
+++ b/app/ai-ethics-statement/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import Contact from "@/components/Contact/Contact";
+import Container from "@/components/Container/Container";
+import Footer from "@/components/Footer/Footer";
+
+export const metadata: Metadata = {
+    title: "AI Ethics Statement",
+    description: "How I use AI responsibly in my work.",
+    alternates: { canonical: "/ai-ethics-statement" },
+};
+
+export default function AIEthicsStatementPage() {
+    return (
+        <>
+            <Container as="section">
+                <h1>AI Ethics Statement</h1>
+                <p>
+                    I use artificial intelligence to edit articles and generate
+                    code throughout this site. The following principles guide
+                    that work:
+                </p>
+                <ul>
+                    <li>Transparency about when AI is involved.</li>
+                    <li>
+                        Accountability for reviewing and validating all
+                        AI-generated content.
+                    </li>
+                    <li>Fairness and avoidance of biased outcomes.</li>
+                    <li>
+                        Respect for privacy and protection of sensitive data.
+                    </li>
+                    <li>
+                        Commitment to accuracy, safety, and human oversight.
+                    </li>
+                </ul>
+                <p>
+                    These principles align with broader professional ethical
+                    standards for computing practitioners.
+                </p>
+            </Container>
+            <Contact />
+            <Footer />
+        </>
+    );
+}

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -22,6 +22,11 @@ export default function Footer() {
                                 Accessibility Statement
                             </Link>
                         </li>
+                        <li>
+                            <Link href="/ai-ethics-statement">
+                                AI Ethics Statement
+                            </Link>
+                        </li>
                     </ul>
                 </nav>
                 <ul className={styles.social}>


### PR DESCRIPTION
## Summary
- add AI ethics statement page outlining responsible use of AI
- link the new AI ethics statement from the site footer

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npx playwright install`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e6ee3c388328be3d7aebf1750c92