### PR TITLE
Link insights section to articles and align articles page styling

### DIFF
--- a/app/articles/page.module.scss
+++ b/app/articles/page.module.scss
@@ -1,9 +1,18 @@
-.cards {
-    display: grid;
-    gap: 1rem;
-}
+@use "../../styles/mixins" as *;
 
-.cards a {
-    text-decoration: none;
-    color: inherit;
+@layer components {
+    .cards {
+        @include card-grid();
+    }
+
+    .cards a {
+        text-decoration: none;
+        color: inherit;
+    }
+
+    @container (min-width:50rem) {
+        .cards {
+            grid-template-columns: repeat(1, 1fr);
+        }
+    }
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Card from "@/components/Card/Card";
 import Contact from "@/components/Contact/Contact";
-import Container from "@/components/Container/Container";
 import Footer from "@/components/Footer/Footer";
+import Section from "@/components/Section/Section";
 import { getAllArticles } from "@/lib/articles";
 import styles from "./page.module.scss";
 
@@ -34,8 +34,7 @@ export default async function ArticlesPage() {
     const articles = await getAllArticles();
     return (
         <>
-            <Container as="section">
-                <h1>Articles</h1>
+            <Section heading="Articles" headingLevel={1}>
                 <div className={styles.cards}>
                     {articles.map(({ year, slug, title, summary }) => (
                         <Link
@@ -48,7 +47,7 @@ export default async function ArticlesPage() {
                         </Link>
                     ))}
                 </div>
-            </Container>
+            </Section>
             <Contact />
             <Footer />
         </>

--- a/components/Insights/Insights.module.scss
+++ b/components/Insights/Insights.module.scss
@@ -14,6 +14,10 @@
         color: inherit;
     }
 
+    .cta {
+        @include cta-group;
+    }
+
     @container (min-width:50rem) {
         .cards {
             grid-template-columns: repeat(1, 1fr);

--- a/components/Insights/Insights.tsx
+++ b/components/Insights/Insights.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Button from "@/components/Button/Button";
 import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import styles from "./Insights.module.scss";
@@ -41,6 +42,11 @@ export default function Insights({ articles }: { articles: Article[] }) {
                         </Link>
                     ),
                 )}
+            </div>
+            <div className={styles.cta}>
+                <Button href="/articles" variant="secondary">
+                    All articles
+                </Button>
             </div>
         </Section>
     );

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -12,7 +12,9 @@ test("articles index is accessible", async ({ page }) => {
 });
 
 test("article page is accessible", async ({ page }) => {
-    await page.goto("/articles/2025/on-freedom-curiosity-and-happiness");
+    await page.goto(
+        "/articles/2025/what-recovering-from-a-stroke-at-36-taught-me",
+    );
     await expect(page.locator("article")).toBeVisible();
     const accessibilityScanResults = await new AxeBuilder({ page })
         .include("main")

--- a/tests/sitemap.spec.ts
+++ b/tests/sitemap.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 test("sitemap URLs match canonical URLs", async ({ request }) => {
-    const articlePath = "/articles/2025/on-freedom-curiosity-and-happiness/";
+    const articlePath =
+        "/articles/2025/what-recovering-from-a-stroke-at-36-taught-me/";
     const articleUrl = `https://lapidist.net${articlePath}`;
 
     const sitemapResponse = await request.get("/sitemap.xml");


### PR DESCRIPTION
## Summary
- add CTA button linking the Insights section to the full articles index
- restyle the articles index using Section and card-grid mixin for consistent layout
- update tests to reference existing article slug

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7746b688328b4895f26bd98f74d