### PR TITLE
feat: center services heading

### DIFF
--- a/components/Services/Services.module.scss
+++ b/components/Services/Services.module.scss
@@ -1,6 +1,10 @@
 @use "../../styles/mixins" as *;
 
 @layer components {
+    .heading {
+        text-align: center;
+    }
+
     .cards {
         @include card-grid();
     }

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -9,7 +9,11 @@ import styles from "./Services.module.scss";
 
 export default function Services() {
     return (
-        <Section id="services" heading="Signature services">
+        <Section
+            id="services"
+            heading="Signature services"
+            headingClassName={styles.heading}
+        >
             <div className={styles.cards}>
                 <Card
                     title="Design System Bootstrap"


### PR DESCRIPTION
## Summary
- center the "Signature services" heading within its section

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test` *(fails: Timed out waiting 120000ms from config.webServer)*


------
https://chatgpt.com/codex/tasks/task_e_68a1f74be4a8832898593165a77dab12