### PR TITLE
feat: add article table of contents

### DIFF
--- a/app/articles/[year]/[slug]/page.tsx
+++ b/app/articles/[year]/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
+import TableOfContents from "@/components/TableOfContents/TableOfContents";
 import { getAllArticles, getArticle } from "@/lib/articles";
 import { buildArticleStructuredData } from "@/lib/structured-data";
 import styles from "./page.module.scss";
@@ -17,7 +18,7 @@ export default async function ArticlePage({
     params: Promise<{ year: string; slug: string }>;
 }) {
     const { year, slug } = await params;
-    const { meta, content, wordCount } = await getArticle(year, slug);
+    const { meta, content, wordCount, headings } = await getArticle(year, slug);
     const structuredData = buildArticleStructuredData(
         meta,
         year,
@@ -45,6 +46,9 @@ export default async function ArticlePage({
                                 : ""}
                             {meta.readingTime}
                         </p>
+                    )}
+                    {headings.length > 0 && (
+                        <TableOfContents headings={headings} />
                     )}
                     {content}
                 </article>

--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -1,0 +1,47 @@
+@layer components {
+    .toc {
+        padding: var(--space-m);
+        border: 1px solid var(--colour-border);
+        border-radius: var(--radius-m);
+        background: var(--surface-level-1);
+    }
+
+    .list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: var(--space-xs);
+    }
+
+    .item[data-level="3"] {
+        margin-inline-start: var(--space-m);
+    }
+
+    .item[data-level="4"] {
+        margin-inline-start: calc(var(--space-m) * 2);
+    }
+
+    .item[data-level="5"] {
+        margin-inline-start: calc(var(--space-m) * 3);
+    }
+
+    .item[data-level="6"] {
+        margin-inline-start: calc(var(--space-m) * 4);
+    }
+
+    .link {
+        text-decoration: none;
+        color: var(--colour-text);
+    }
+
+    .link:focus-visible {
+        text-decoration: underline;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .link:hover {
+            text-decoration: underline;
+        }
+    }
+}

--- a/components/TableOfContents/TableOfContents.stories.tsx
+++ b/components/TableOfContents/TableOfContents.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import TableOfContents, {
+    type TableOfContentsHeading,
+} from "./TableOfContents";
+
+const sampleHeadings: TableOfContentsHeading[] = [
+    { id: "section-1", text: "Section 1", level: 2 },
+    { id: "subsection-1-1", text: "Subsection 1.1", level: 3 },
+    { id: "section-2", text: "Section 2", level: 2 },
+];
+
+const meta = {
+    title: "Components/TableOfContents",
+    component: TableOfContents,
+    args: {
+        headings: sampleHeadings,
+    },
+} satisfies Meta<typeof TableOfContents>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/components/TableOfContents/TableOfContents.tsx
+++ b/components/TableOfContents/TableOfContents.tsx
@@ -1,0 +1,38 @@
+import type { FC } from "react";
+import styles from "./TableOfContents.module.scss";
+
+export type TableOfContentsHeading = {
+    id: string;
+    text: string;
+    level: number;
+};
+
+type Props = {
+    headings: TableOfContentsHeading[];
+};
+
+const TableOfContents: FC<Props> = ({ headings }) => {
+    if (headings.length === 0) {
+        return null;
+    }
+
+    return (
+        <nav aria-label="Table of contents" className={styles.toc}>
+            <ol className={styles.list}>
+                {headings.map((heading) => (
+                    <li
+                        key={heading.id}
+                        className={styles.item}
+                        data-level={heading.level}
+                    >
+                        <a href={`#${heading.id}`} className={styles.link}>
+                            {heading.text}
+                        </a>
+                    </li>
+                ))}
+            </ol>
+        </nav>
+    );
+};
+
+export default TableOfContents;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
             "dependencies": {
                 "@lapidist/cv-generator": "2.4.0",
                 "clsx": "2.1.1",
+                "github-slugger": "^2.0.0",
                 "gray-matter": "4.0.3",
+                "mdast-util-to-string": "^4.0.0",
                 "next": "15.4.6",
                 "next-mdx-remote": "5.0.0",
                 "prettier": "3.6.2",
@@ -19,7 +21,8 @@
                 "react-dom": "19.1.1",
                 "remark": "^15.0.1",
                 "remark-gfm": "^4.0.1",
-                "remark-reading-time": "^2.0.2"
+                "remark-reading-time": "^2.0.2",
+                "unist-util-visit": "^5.0.0"
             },
             "devDependencies": {
                 "@axe-core/playwright": "4.10.2",
@@ -12383,6 +12386,12 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/github-slugger": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+            "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+            "license": "ISC"
         },
         "node_modules/glob": {
             "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "dependencies": {
         "@lapidist/cv-generator": "2.4.0",
         "clsx": "2.1.1",
+        "github-slugger": "^2.0.0",
         "gray-matter": "4.0.3",
+        "mdast-util-to-string": "^4.0.0",
         "next": "15.4.6",
         "next-mdx-remote": "5.0.0",
         "prettier": "3.6.2",
@@ -45,7 +47,8 @@
         "react-dom": "19.1.1",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
-        "remark-reading-time": "^2.0.2"
+        "remark-reading-time": "^2.0.2",
+        "unist-util-visit": "^5.0.0"
     },
     "devDependencies": {
         "@axe-core/playwright": "4.10.2",

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -16,6 +16,9 @@ test("article page is accessible", async ({ page }) => {
         "/articles/2025/what-recovering-from-a-stroke-at-36-taught-me",
     );
     await expect(page.locator("article")).toBeVisible();
+    await expect(
+        page.locator('nav[aria-label="Table of contents"]'),
+    ).toBeVisible();
     const accessibilityScanResults = await new AxeBuilder({ page })
         .include("main")
         .exclude('[role="alert"]')


### PR DESCRIPTION
## Summary
- add TableOfContents component with design token styling and storybook story
- extract markdown headings while compiling articles
- render accessible table of contents on article page

## Testing
- `npm run lint`
- `npm run format`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fc6c2f9c8328a83da6890c7afad2