### PR TITLE
Account for header height on anchor navigation

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Container from "@/components/Container/Container";
@@ -11,21 +11,47 @@ import LogoMark from "./LogoMark";
 export default function Header() {
     const pathname = usePathname();
     const [scrolled, setScrolled] = useState(false);
+    const headerRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
         function onScroll() {
             setScrolled(window.scrollY > 0);
         }
 
+        function onResize() {
+            if (headerRef.current) {
+                document.documentElement.style.setProperty(
+                    "--header-offset",
+                    `${String(headerRef.current.offsetHeight)}px`,
+                );
+            }
+        }
+
         onScroll();
+        onResize();
         window.addEventListener("scroll", onScroll);
+        window.addEventListener("resize", onResize);
         return () => {
             window.removeEventListener("scroll", onScroll);
+            window.removeEventListener("resize", onResize);
         };
     }, []);
 
+    useEffect(() => {
+        if (window.location.hash) {
+            const el = document.getElementById(
+                window.location.hash.substring(1),
+            );
+            el?.scrollIntoView();
+        }
+    }, []);
+
     return (
-        <header className={styles.header} data-scrolled={scrolled || undefined}>
+        <header
+            ref={headerRef}
+            className={styles.header}
+            data-scrolled={scrolled || undefined}
+        >
             <Container className={styles.inner} as="div" cq="page">
                 <nav role="navigation">
                     <Link

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -20,6 +20,7 @@
 
     html {
         scroll-behavior: smooth;
+        scroll-padding-block-start: var(--header-offset, 0);
         scrollbar-width: thin;
         scrollbar-color: var(--colour-primary) var(--surface-level-1);
         accent-color: var(--colour-primary);


### PR DESCRIPTION
## Summary
- ensure anchor navigation scroll offsets by measuring header height and setting `--header-offset`
- apply `scroll-padding-block-start` so hash links account for the sticky header

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fffe76908328bab64c8829a78349