### PR TITLE
feat: style article table of contents

### DIFF
--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -4,6 +4,12 @@
         border: 1px solid var(--colour-border);
         border-radius: var(--radius-m);
         background: var(--surface-level-1);
+        margin-block: var(--space-xl);
+    }
+
+    .heading {
+        margin-block: 0 var(--space-s);
+        font-size: var(--typography-size-200);
     }
 
     .list {
@@ -12,6 +18,7 @@
         padding: 0;
         display: grid;
         gap: var(--space-xs);
+        font-size: var(--typography-size-100);
     }
 
     .item[data-level="3"] {

--- a/components/TableOfContents/TableOfContents.tsx
+++ b/components/TableOfContents/TableOfContents.tsx
@@ -17,7 +17,10 @@ const TableOfContents: FC<Props> = ({ headings }) => {
     }
 
     return (
-        <nav aria-label="Table of contents" className={styles.toc}>
+        <nav aria-labelledby="toc-heading" className={styles.toc}>
+            <p id="toc-heading" className={styles.heading}>
+                Table of contents
+            </p>
             <ol className={styles.list}>
                 {headings.map((heading) => (
                     <li

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -52,7 +52,8 @@ export async function getArticle(year: string, slug: string) {
             const id = slugger.slug(text);
             headings.push({ id, text, level: node.depth });
             const data = node.data || (node.data = {});
-            const props = (data.hProperties as { id?: string } | undefined) || {};
+            const props =
+                (data.hProperties as { id?: string } | undefined) || {};
             props.id = id;
             data.hProperties = props;
         });

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -17,7 +17,7 @@ test("article page is accessible", async ({ page }) => {
     );
     await expect(page.locator("article")).toBeVisible();
     await expect(
-        page.locator('nav[aria-label="Table of contents"]'),
+        page.locator('nav[aria-labelledby="toc-heading"]'),
     ).toBeVisible();
     const accessibilityScanResults = await new AxeBuilder({ page })
         .include("main")


### PR DESCRIPTION
## Summary
- add heading and spacing to article table of contents
- reduce table of contents font size
- update article test for new heading

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers` *(fails: operation interrupted)*
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a200252c3c83288367047b04ce0eb0