### PR TITLE
Surface RSS feed on articles page

### DIFF
--- a/app/articles/page.module.scss
+++ b/app/articles/page.module.scss
@@ -1,6 +1,16 @@
 @use "../../styles/mixins" as *;
 
 @layer components {
+    .heading {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .heading a {
+        font-size: var(--typography-size-200);
+    }
+
     .cards {
         @include card-grid();
     }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -34,7 +34,16 @@ export default async function ArticlesPage() {
     const articles = await getAllArticles();
     return (
         <>
-            <Section heading="Articles" headingLevel={1}>
+            <Section
+                heading={
+                    <>
+                        <span>Articles</span>
+                        <Link href="/rss.xml">RSS feed</Link>
+                    </>
+                }
+                headingClassName={styles.heading}
+                headingLevel={1}
+            >
                 <div className={styles.cards}>
                     {articles.map(({ year, slug, title, summary }) => (
                         <Link

--- a/components/TableOfContents/TableOfContents.tsx
+++ b/components/TableOfContents/TableOfContents.tsx
@@ -18,7 +18,7 @@ const TableOfContents: FC<Props> = ({ headings }) => {
 
     return (
         <nav aria-labelledby="toc-heading" className={styles.toc}>
-            <h3 id="toc-heading">Table of contents</h3>
+            <h2 id="toc-heading">Table of contents</h2>
             <ol className={styles.list}>
                 {headings.map((heading) => (
                     <li

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -4,6 +4,8 @@ import { expect, test } from "@playwright/test";
 test("articles index is accessible", async ({ page }) => {
     await page.goto("/articles");
     await expect(page.locator("h1")).toContainText("Articles");
+    const rssLink = page.getByRole("link", { name: "RSS feed" });
+    await expect(rssLink).toHaveAttribute("href", "/rss.xml");
     const accessibilityScanResults = await new AxeBuilder({ page })
         .include("main")
         .exclude('[role="alert"]')


### PR DESCRIPTION
## Summary
- show RSS feed link on articles index
- adjust Table of Contents heading level for accessibility
- test for RSS link visibility

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20988efb483289d8f73c4a03dfc5b