### PR TITLE
chore: reference next eslint tooling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,9 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
+import nextPlugin from "@next/eslint-plugin-next";
 import eslintPluginImport from "eslint-plugin-import";
+import "eslint-import-resolver-typescript";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import reactCompiler from "eslint-plugin-react-compiler";
 import storybook from "eslint-plugin-storybook";
@@ -30,7 +32,11 @@ export default [
     js.configs.recommended,
     ...tseslint.configs.strictTypeChecked,
     ...storybook.configs["flat/recommended"],
-    ...compat.extends("next/core-web-vitals", "next/typescript"),
+    ...compat.extends(
+        "eslint-config-next",
+        "next/core-web-vitals",
+        "next/typescript",
+    ),
     reactCompiler.configs.recommended,
     {
         rules: {
@@ -38,6 +44,7 @@ export default [
         },
         plugins: {
             import: eslintPluginImport,
+            "@next/next": nextPlugin,
         },
         settings: {
             "import/resolver": {


### PR DESCRIPTION
## Summary
- explicitly reference Next.js ESLint plugin and config
- include TypeScript import resolver to satisfy dependency checks

## Testing
- `npx -y depcheck`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a20a07302c832899b5ff44a46d2c16