### PR TITLE
fix: consolidate global style imports

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Lexend_Deca, Roboto_Mono } from "next/font/google";
-import "@/styles/tokens.scss";
-import "@/styles/globals.scss";
-import "@/styles/typography.scss";
+import "@/styles/index.scss";
 import Header from "@/components/Header/Header";
 import styles from "./layout.module.scss";
 

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,0 +1,3 @@
+@use "./tokens";
+@use "./globals";
+@use "./typography";


### PR DESCRIPTION
## Summary
- consolidate token, global, and typography styles into a single entry point
- update layout to use combined stylesheet so production and dev builds share font and spacing settings

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21069e7d48328b1fb1866c44a293b