### PR TITLE
fix: correct stroke age in article

### DIFF
--- a/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
+++ b/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
@@ -1,7 +1,7 @@
 ---
-title: "What recovering from a stroke at 36 taught me about work, life, and finding a balance"
+title: "What recovering from a stroke at 34 taught me about work, life, and finding a balance"
 date: 2025-08-17
-description: "Reflections on a stroke at 36 and how recovery reshaped my approach to work and health."
+description: "Reflections on a stroke at 34 and how recovery reshaped my approach to work and health."
 summary: "Lessons on burnout, balance, and human-centered engineering learned through my recovery from a stroke in my thirties."
 image: "/opengraph-image"
 author:
@@ -16,7 +16,7 @@ tags:
 
 ## Introduction
 
-At 36 years old, in the prime of my career, I suffered a stroke.
+At 34 years old, in the prime of my career, I suffered a stroke.
 
 On 7th October 2021, around 10pm, I was cooking a late dinner and had a sudden sharp pain in my head, followed by vomiting and weakness. Assuming this was a migraine I went to bed and continued my life as normal. When this headache hadn't lifted by the 11th I phoned NHS 111 and was immediately taken to hospital, where it was revealed that sudden pain was in fact a stroke.
 
@@ -38,7 +38,7 @@ I'm a Frontend Engineer and design systems specialist with over 15 years in web 
 
 Looking back, the warning signs were there. I had been working long hours, immersed in a tech culture that prizes speed and relentless delivery. In many software companies, the pursuit of lightning-fast achievement leads developers to neglect basic needs like rest and mental health. I was no exception. Before my stroke, I regularly pushed through 12-hour days fueled by caffeine and a sense of misplaced duty. I learned I was far from alone – burnout in our industry is at epidemic levels, with a 2021 survey finding that 83% of developers felt overextended or exhausted.[^1] Tech leaders often celebrate "grind" culture, but rarely talk about its human cost.
 
-Recovering from my health crisis forced me to reevaluate everything: how I work, how I lead, and how I live. This article isn't just a personal memoir of recovery; it’s a set of hard-won insights for frontend engineers, design system practitioners, and engineering leaders. I'll share how surviving burnout and a stroke at 36 redefined my approach to work and life. My hope is that these lessons can help others in tech avoid the mistakes I made and build a healthier, more resilient career in the long run.
+Recovering from my health crisis forced me to reevaluate everything: how I work, how I lead, and how I live. This article isn't just a personal memoir of recovery; it’s a set of hard-won insights for frontend engineers, design system practitioners, and engineering leaders. I'll share how surviving burnout and a stroke at 34 redefined my approach to work and life. My hope is that these lessons can help others in tech avoid the mistakes I made and build a healthier, more resilient career in the long run.
 
 ## The shock of burnout and health collapse
 
@@ -89,7 +89,7 @@ Finally, I want to distill everything I've learned into a few actionable insight
 
 ## Conclusion
 
-Recovering from a stroke at 36 was never part of my career plan, but in hindsight it's been a profound teacher. It brutally highlighted the cost of the unsustainable way I was working, and it gave me the clarity (and frankly, the permission) to realign my priorities. Nothing clarifies what truly matters like a brush with your own mortality.
+Recovering from a stroke at 34 was never part of my career plan, but in hindsight it's been a profound teacher. It brutally highlighted the cost of the unsustainable way I was working, and it gave me the clarity (and frankly, the permission) to realign my priorities. Nothing clarifies what truly matters like a brush with your own mortality.
 
 As engineers, we pride ourselves on building scalable, resilient systems. We design our applications with failure handling, maintenance, and longevity in mind. We should treat our own health with the same foresight and care.
 

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -15,7 +15,7 @@ test("articles index is accessible", async ({ page }) => {
 
 test("article page is accessible", async ({ page }) => {
     await page.goto(
-        "/articles/2025/what-recovering-from-a-stroke-at-36-taught-me",
+        "/articles/2025/what-recovering-from-a-stroke-at-34-taught-me",
     );
     await expect(page.locator("article")).toBeVisible();
     await expect(

--- a/tests/sitemap.spec.ts
+++ b/tests/sitemap.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("sitemap URLs match canonical URLs", async ({ request }) => {
     const articlePath =
-        "/articles/2025/what-recovering-from-a-stroke-at-36-taught-me/";
+        "/articles/2025/what-recovering-from-a-stroke-at-34-taught-me/";
     const articleUrl = `https://lapidist.net${articlePath}`;
 
     const sitemapResponse = await request.get("/sitemap.xml");


### PR DESCRIPTION
## Summary
- update stroke article to show age 34
- adjust tests for updated article slug

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers` *(failed: operation interrupted)*
- `npm test` *(failed: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a223dc40188328938629099c84b386