### PR TITLE
Remove unsupported areaServed from Person schema

### DIFF
--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -17,7 +17,6 @@ const PERSON = {
         addressLocality: "Glasgow",
         addressCountry: "GB",
     },
-    areaServed: ["United Kingdom", "Remote"],
     knowsAbout: [
         "frontend",
         "design systems",


### PR DESCRIPTION
## Summary
- remove invalid `areaServed` field from Person structured data

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: article page is accessible - color contrast)*

------
https://chatgpt.com/codex/tasks/task_e_68a22cd362c48328b552150e05bef868