### PR TITLE
Add address info to services schema

### DIFF
--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,5 +1,11 @@
 const BASE = "https://lapidist.net";
 
+const ADDRESS = {
+    "@type": "PostalAddress",
+    addressLocality: "Glasgow",
+    addressCountry: "UK",
+} as const;
+
 const PERSON = {
     "@type": "Person",
     "@id": `${BASE}#person`,
@@ -12,11 +18,7 @@ const PERSON = {
         contactType: "enquiries",
         email: "hello@lapidist.net",
     },
-    address: {
-        "@type": "PostalAddress",
-        addressLocality: "Glasgow",
-        addressCountry: "GB",
-    },
+    address: ADDRESS,
     areaServed: ["United Kingdom", "Remote"],
     knowsAbout: [
         "frontend",
@@ -91,6 +93,7 @@ export function buildHomePageStructuredData(datePublished: string) {
                 description:
                     "Launch a production-ready design system in weeks – boosting velocity, cutting rework, and improving accessibility from day one.",
                 provider: { "@id": `${BASE}#person` },
+                address: ADDRESS,
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
                     "@type": "AggregateOffer",
@@ -105,6 +108,7 @@ export function buildHomePageStructuredData(datePublished: string) {
                 description:
                     "Turn existing assets into a strategic UI architecture roadmap that reduces churn and flags risk early.",
                 provider: { "@id": `${BASE}#person` },
+                address: ADDRESS,
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
                     "@type": "AggregateOffer",
@@ -119,6 +123,7 @@ export function buildHomePageStructuredData(datePublished: string) {
                 description:
                     "Ship resilient foundations without diverting your team so releases stay on schedule.",
                 provider: { "@id": `${BASE}#person` },
+                address: ADDRESS,
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
                     "@type": "AggregateOffer",
@@ -133,6 +138,7 @@ export function buildHomePageStructuredData(datePublished: string) {
                 description:
                     "Raise team capability with ongoing mentorship that lifts quality and autonomy.",
                 provider: { "@id": `${BASE}#person` },
+                address: ADDRESS,
                 areaServed: ["United Kingdom", "Remote"],
                 offers: {
                     "@type": "AggregateOffer",


### PR DESCRIPTION
## Summary
- add shared Glasgow postal address constant
- include address data for person and each service offering

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: Accessibility violations on article page)*

------
https://chatgpt.com/codex/tasks/task_e_68a22eb56898832898f427e4e7a5b8d2