### PR TITLE
Escape ampersands in RSS feed

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
             ? new Date(articles[0].date).toUTCString()
             : new Date().toUTCString();
 
-    const rss = `<?xml version="1.0" encoding="UTF-8" ?>\n<rss version="2.0">\n    <channel>\n        <title>${SITE_TITLE}</title>\n        <link>${BASE_URL}</link>\n        <description>${SITE_DESCRIPTION}</description>\n        <language>en-GB</language>\n        <lastBuildDate>${lastBuildDate}</lastBuildDate>\n        <image>\n            <url>${BASE_URL}/opengraph-image</url>\n            <title>${SITE_TITLE}</title>\n            <link>${BASE_URL}</link>\n        </image>${items}\n    </channel>\n</rss>`;
+    const rss = `<?xml version="1.0" encoding="UTF-8" ?>\n<rss version="2.0">\n    <channel>\n        <title>${escapeHtml(SITE_TITLE)}</title>\n        <link>${BASE_URL}</link>\n        <description>${escapeHtml(SITE_DESCRIPTION)}</description>\n        <language>en-GB</language>\n        <lastBuildDate>${lastBuildDate}</lastBuildDate>\n        <image>\n            <url>${BASE_URL}/opengraph-image</url>\n            <title>${escapeHtml(SITE_TITLE)}</title>\n            <link>${BASE_URL}</link>\n        </image>${items}\n    </channel>\n</rss>`;
 
     return new Response(rss, {
         headers: {


### PR DESCRIPTION
## Summary
- escape site title and description when generating RSS XML

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test` *(fails: dark article page accessibility)*

------
https://chatgpt.com/codex/tasks/task_e_68a22efecb388328b0575869a32aa306