### PR TITLE
Remove invalid priceRange from structured data

### DIFF
--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -97,7 +97,6 @@ export function buildHomePageStructuredData(datePublished: string) {
                 offers: {
                     "@type": "AggregateOffer",
                     priceCurrency: "GBP",
-                    priceRange: "£££",
                 },
             },
             {
@@ -112,7 +111,6 @@ export function buildHomePageStructuredData(datePublished: string) {
                 offers: {
                     "@type": "AggregateOffer",
                     priceCurrency: "GBP",
-                    priceRange: "£££",
                 },
             },
             {
@@ -127,7 +125,6 @@ export function buildHomePageStructuredData(datePublished: string) {
                 offers: {
                     "@type": "AggregateOffer",
                     priceCurrency: "GBP",
-                    priceRange: "£££",
                 },
             },
             {
@@ -142,7 +139,6 @@ export function buildHomePageStructuredData(datePublished: string) {
                 offers: {
                     "@type": "AggregateOffer",
                     priceCurrency: "GBP",
-                    priceRange: "£££",
                 },
             },
             {


### PR DESCRIPTION
## Summary
- remove `priceRange` from `AggregateOffer` structured data entries to align with schema.org

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: Accessibility violation on article page)*

------
https://chatgpt.com/codex/tasks/task_e_68a23289321483289b9037126c8ab1d1