### PR TITLE
fix: load RSS feed via anchor

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -38,7 +38,7 @@ export default async function ArticlesPage() {
                 heading={
                     <>
                         <span>Articles</span>
-                        <Link href="/rss.xml">RSS feed</Link>
+                        <a href="/rss.xml">RSS feed</a>
                     </>
                 }
                 headingClassName={styles.heading}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -75,7 +75,8 @@
 
     a:not([class]) {
         color: var(--colour-primary);
-        text-decoration: none;
+        text-decoration: underline;
+        text-decoration-color: currentcolor;
         transition:
             color var(--motion-dur-200) var(--motion-ease-standard),
             text-decoration-color var(--motion-dur-200)


### PR DESCRIPTION
## Summary
- use a plain `<a>` tag for the RSS feed to stop Next.js prefetch from requesting `/rss.xml.txt`
- underline un-classed links for accessibility

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23df22ba88328a51208ec302e7013