### PR TITLE
chore: remove underline from insights cards

### DIFF
--- a/components/Insights/Insights.module.scss
+++ b/components/Insights/Insights.module.scss
@@ -9,7 +9,7 @@
         @include card-grid();
     }
 
-    .cards a {
+    .cardLink {
         text-decoration: none;
         color: inherit;
     }

--- a/components/Insights/Insights.tsx
+++ b/components/Insights/Insights.tsx
@@ -36,6 +36,7 @@ export default function Insights({ articles }: { articles: Article[] }) {
                         <Link
                             key={`${year}-${slug}`}
                             href={`/articles/${year}/${slug}`}
+                            className={styles.cardLink}
                         >
                             <Card title={title}>
                                 <p>{summary}</p>


### PR DESCRIPTION
## Summary
- avoid global anchor underline on insights cards by adding custom class
- ensure card links inherit text color and no text decoration

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24fc6aa0c8328bdc9295076ff16f0