### PR TITLE
Remove underline from article card links

### DIFF
--- a/app/articles/page.module.scss
+++ b/app/articles/page.module.scss
@@ -15,7 +15,7 @@
         @include card-grid();
     }
 
-    .cards a {
+    .cardLink {
         text-decoration: none;
         color: inherit;
     }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -59,6 +59,7 @@ export default async function ArticlesPage() {
                             <Link
                                 key={`${year}-${slug}`}
                                 href={`/articles/${year}/${slug}`}
+                                className={styles.cardLink}
                             >
                                 <Card title={title} headingLevel="h2">
                                     <p>{summary}</p>


### PR DESCRIPTION
## Summary
- prevent article list cards from inheriting global link underline
- style article card links with inherited color

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2539c75e4832884b2022aa46e0fd7