### PR TITLE
feat: add return to articles link

### DIFF
--- a/app/articles/[year]/[slug]/page.module.scss
+++ b/app/articles/[year]/[slug]/page.module.scss
@@ -14,6 +14,11 @@
         font-size: var(--typography-size-100);
     }
 
+    .return {
+        margin-top: var(--space-xl);
+        font-size: var(--typography-size-100);
+    }
+
     .article :global(ol) {
         display: grid;
         gap: var(--space-l);

--- a/app/articles/[year]/[slug]/page.tsx
+++ b/app/articles/[year]/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import Contact from "@/components/Contact/Contact";
 import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
@@ -51,6 +52,9 @@ export default async function ArticlePage({
                     )}
                     {content}
                 </article>
+                <p className={styles.return}>
+                    <Link href="/articles">Return to articles</Link>
+                </p>
             </Section>
             <Contact />
             <Footer />


### PR DESCRIPTION
## Summary
- add navigation link back to articles index on article pages

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a253f1219c83289dea296ab6d8e0ba