### PR TITLE
feat: enhance social share images

### DIFF
--- a/app/articles/[year]/[slug]/opengraph-image.tsx
+++ b/app/articles/[year]/[slug]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { getAllArticles, getArticle } from "@/lib/articles";
 
 export const dynamic = "force-static";
 export const size = { width: 1200, height: 630 };
@@ -34,7 +35,19 @@ function LogoLockup() {
     );
 }
 
-export default function OGImage() {
+export async function generateStaticParams() {
+    const articles = await getAllArticles();
+    return articles.map(({ year, slug }) => ({ year, slug }));
+}
+
+export default async function OGImage({
+    params,
+}: {
+    params: Promise<{ year: string; slug: string }>;
+}) {
+    const { year, slug } = await params;
+    const { meta } = await getArticle(year, slug);
+
     return new ImageResponse(
         (
             <div
@@ -54,8 +67,14 @@ export default function OGImage() {
                 }}
             >
                 <LogoLockup />
-                <span style={{ fontSize: 56 }}>
-                    Ship design systems teams love.
+                <span
+                    style={{
+                        fontSize: 56,
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                    }}
+                >
+                    {meta.title}
                 </span>
             </div>
         ),

--- a/app/articles/[year]/[slug]/page.tsx
+++ b/app/articles/[year]/[slug]/page.tsx
@@ -67,6 +67,8 @@ export async function generateMetadata({
     const { meta } = await getArticle(year, slug);
     const base = "https://lapidist.net";
     const url = `${base}/articles/${year}/${slug}/`;
+    const ogImage = `/articles/${year}/${slug}/opengraph-image`;
+    const twitterImage = `/articles/${year}/${slug}/twitter-image`;
     return {
         title: meta.title,
         description: meta.description,
@@ -77,14 +79,14 @@ export async function generateMetadata({
             url,
             type: "article",
             publishedTime: meta.date,
-            images: meta.image ? [{ url: meta.image }] : undefined,
+            images: [{ url: ogImage }],
             authors: meta.author.url ? [meta.author.url] : undefined,
         },
         twitter: {
             card: "summary_large_image",
             title: meta.title,
             description: meta.description,
-            images: meta.image ? [meta.image] : undefined,
+            images: [twitterImage],
         },
     };
 }

--- a/app/articles/[year]/[slug]/twitter-image.tsx
+++ b/app/articles/[year]/[slug]/twitter-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og";
+import { getAllArticles, getArticle } from "@/lib/articles";
 
 export const dynamic = "force-static";
-export const size = { width: 1200, height: 630 };
+export const size = { width: 1600, height: 900 };
 export const contentType = "image/png";
 
 const LOGO_COLORS = {
@@ -34,7 +35,19 @@ function LogoLockup() {
     );
 }
 
-export default function OGImage() {
+export async function generateStaticParams() {
+    const articles = await getAllArticles();
+    return articles.map(({ year, slug }) => ({ year, slug }));
+}
+
+export default async function TwitterImage({
+    params,
+}: {
+    params: Promise<{ year: string; slug: string }>;
+}) {
+    const { year, slug } = await params;
+    const { meta } = await getArticle(year, slug);
+
     return new ImageResponse(
         (
             <div
@@ -46,7 +59,7 @@ export default function OGImage() {
                     justifyContent: "space-between",
                     background: "#000",
                     color: "#fff",
-                    padding: "80px",
+                    padding: "96px",
                     fontFamily: "sans-serif",
                     backgroundImage:
                         "linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px)",
@@ -54,8 +67,14 @@ export default function OGImage() {
                 }}
             >
                 <LogoLockup />
-                <span style={{ fontSize: 56 }}>
-                    Ship design systems teams love.
+                <span
+                    style={{
+                        fontSize: 72,
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                    }}
+                >
+                    {meta.title}
                 </span>
             </div>
         ),

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -4,6 +4,36 @@ export const dynamic = "force-static";
 export const size = { width: 1600, height: 900 };
 export const contentType = "image/png";
 
+const LOGO_COLORS = {
+    blue: "#00af9f",
+    green: "#92ca6b",
+    yellow: "#e9ba4d",
+} as const;
+
+function LogoLockup() {
+    return (
+        <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
+            <svg width={128} height={128} viewBox="0 0 64 64">
+                <polygon points="0,0 0,32 32,32" fill={LOGO_COLORS.blue} />
+                <polygon points="0,32 0,64 32,64" fill={LOGO_COLORS.green} />
+                <polygon points="32,0 32,64 64,32" fill={LOGO_COLORS.yellow} />
+            </svg>
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    fontSize: 64,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                }}
+            >
+                <span>Brett</span>
+                <span>Dorrans</span>
+            </div>
+        </div>
+    );
+}
+
 export default function TwitterImage() {
     return new ImageResponse(
         (
@@ -13,7 +43,7 @@ export default function TwitterImage() {
                     height: "100%",
                     display: "flex",
                     flexDirection: "column",
-                    justifyContent: "center",
+                    justifyContent: "space-between",
                     background: "#000",
                     color: "#fff",
                     padding: "96px",
@@ -23,13 +53,8 @@ export default function TwitterImage() {
                     backgroundSize: "40px 40px",
                 }}
             >
-                <span style={{ fontSize: 80, fontWeight: 700 }}>
-                    Brett Dorrans
-                </span>
-                <span style={{ fontSize: 56 }}>
-                    Lead Frontend Engineer & Design Systems Specialist
-                </span>
-                <span style={{ fontSize: 48 }}>
+                <LogoLockup />
+                <span style={{ fontSize: 72 }}>
                     Ship design systems teams love.
                 </span>
             </div>


### PR DESCRIPTION
## Summary
- polish default Open Graph and Twitter card images with logo lockup and tagline
- generate dynamic social images for articles using their titles
- wire article metadata to new Open Graph and Twitter image routes

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a252a146dc8328a602dd538c062ffc