### PR TITLE
Align footnote list padding

### DIFF
--- a/app/articles/[year]/[slug]/page.module.scss
+++ b/app/articles/[year]/[slug]/page.module.scss
@@ -68,7 +68,7 @@
         display: grid;
         gap: var(--space-xs);
         margin: 0;
-        padding-left: var(--space-l);
+        padding-left: var(--space-2xl);
     }
 
     .article :global(.footnotes li p) {


### PR DESCRIPTION
## Summary
- increase left padding on footnote lists to match numbered list alignment

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2585551188328a24fdfabe44563a1