### PR TITLE
docs: restore stroke recovery article voice

### DIFF
--- a/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
+++ b/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
@@ -2,7 +2,7 @@
 title: "What recovering from a stroke at 34 taught me about work, life, and finding a balance"
 date: 2025-08-17
 description: "Reflections on a stroke at 34 and how recovery reshaped my approach to work and health."
-summary: "Lessons on burnout, balance, and human-centered engineering learned through my recovery from a stroke in my thirties."
+summary: "Lessons on burnout, balance, and human-centred engineering learned through my recovery from a stroke in my thirties."
 image: "/opengraph-image"
 author:
     name: "Brett Dorrans"
@@ -36,9 +36,9 @@ I was in a hospital bed grappling with paralysis and uncertainty. Strokes were s
 
 I'm a Frontend Engineer and design systems specialist with over 15 years in web development. I've built design systems from scratch, scaled frontend architecture for enterprise SaaS products, and led engineering teams through high-pressure fintech launches. I was used to solving complex problems under tight deadlines and prided myself on being the go-to person for all things frontend. But none of that technical expertise prepared me for the challenge of rebuilding my health from the ground up.
 
-Looking back, the warning signs were there. I had been working long hours, immersed in a tech culture that prizes speed and relentless delivery. In many software companies, the pursuit of lightning-fast achievement leads developers to neglect basic needs like rest and mental health. I was no exception. Before my stroke, I regularly pushed through 12-hour days fueled by caffeine and a sense of misplaced duty. I learned I was far from alone – burnout in our industry is at epidemic levels, with a 2021 survey finding that 83% of developers felt overextended or exhausted.[^1] Tech leaders often celebrate "grind" culture, but rarely talk about its human cost.
+Looking back, the warning signs were there. I had been working long hours, immersed in a tech culture that prizes speed and relentless delivery. In many software companies, the pursuit of lightning-fast achievement leads developers to neglect basic needs like rest and mental health. I was no exception. Before my stroke, I regularly pushed through 12-hour days fuelled by caffeine and a sense of misplaced duty. I learned I was far from alone – burnout in our industry is at epidemic levels, with a 2021 survey finding that 83% of developers felt overextended or exhausted.[^1] Tech leaders often celebrate "grind" culture, but rarely talk about its human cost.
 
-Recovering from my health crisis forced me to reevaluate everything: how I work, how I lead, and how I live. This article isn't just a personal memoir of recovery; it’s a set of hard-won insights for frontend engineers, design system practitioners, and engineering leaders. I'll share how surviving burnout and a stroke at 34 redefined my approach to work and life. My hope is that these lessons can help others in tech avoid the mistakes I made and build a healthier, more resilient career in the long run.
+Recovering from my health crisis forced me to re-evaluate everything: how I work, how I lead, and how I live. This article isn't just a personal memoir of recovery; it’s a set of hard-won insights for frontend engineers, design system practitioners, and engineering leaders. I'll share how surviving burnout and a stroke at 34 redefined my approach to work and life. My hope is that these lessons can help others in tech avoid the mistakes I made and build a healthier, more resilient career in the long run.
 
 ## The shock of burnout and health collapse
 
@@ -66,7 +66,7 @@ I also learned that saying "no" can be the most productive move. Before, I was a
 
 Surprisingly, the world didn't end when I pushed back on requests or asked for more time. Instead, something amazing happened: I found that setting boundaries earned me respect. By diplomatically saying "I can't take this on right now" or "this deadline isn't feasible without risking quality," I opened honest dialogues with my team and managers. We'd re-prioritise or find another way. It turns out that being clear about your limits is healthy for both you and the product. As a bonus, it teaches your team that it's okay to set boundaries of their own.
 
-## Human-centered engineering
+## Human-centred engineering
 
 Before my health crisis, I viewed engineering leadership primarily as shipping features, refining architecture, and mentoring code quality. Those are all important, but my perspective broadened significantly after the stroke. I came to realise that one of the most critical roles of an engineering leader is protecting the humans who build the software. A team that is burnt out, stressed, or unhealthy will eventually grind to a halt, no matter how brilliant the individuals are. Conversely, a team that feels supported and balanced will sustain high performance and creativity. As a leader, it’s my job to cultivate the latter and prevent the former.
 
@@ -85,7 +85,7 @@ Finally, I want to distill everything I've learned into a few actionable insight
 1. **Rest is strategic.** High performance in software engineering is not about constant grind; it's about smart recovery cycles. Treat sleep, breaks, and time off as essential parts of your workflow - they will make your code and decisions better, not worse.
 2. **Stress compounds silently.** Unchecked stress accumulates over time. Don't wait until you hit a wall; start implementing stress-reduction habits at the first warning signs. It's much easier to course-correct early than recover from a total collapse.
 3. **Build sustainable systems.** As an engineer or leader, invest in tooling, automation, and processes that make life easier for the team. Automate the painful deploys, document the common patterns, create reusable components - reduce cognitive load wherever possible. The less brainpower wasted on drudgery or uncertainty, the more energy available for creative, fulfilling work.
-4. **Leaders should model balance.** If you’re in any kind of leadership role (even just as a senior dev mentoring others), know that your team will take cues from you. Modeling work/life balance is one of the most impactful things you can do. When you take care of your health and openly set boundaries, you give others permission to do the same.
+4. **Leaders should model balance.** If you’re in any kind of leadership role (even just as a senior dev mentoring others), know that your team will take cues from you. Modelling work/life balance is one of the most impactful things you can do. When you take care of your health and openly set boundaries, you give others permission to do the same.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- revert heavy rewrite of stroke recovery article to preserve original tone
- apply light British English edits and spelling corrections

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25961df08832890df564f493d12ce