### PR TITLE
refactor: introduce grid-stack and flex-between mixins

### DIFF
--- a/app/articles/[year]/[slug]/page.module.scss
+++ b/app/articles/[year]/[slug]/page.module.scss
@@ -1,7 +1,8 @@
+@use "../../../../styles/mixins" as *;
+
 @layer components {
     .article {
-        display: grid;
-        gap: var(--space-sm);
+        @include grid-stack(var(--space-sm));
     }
 
     .summary {
@@ -21,8 +22,7 @@
     }
 
     .article :global(ol) {
-        display: grid;
-        gap: var(--space-l);
+        @include grid-stack(var(--space-l));
     }
 
     .article :global(blockquote) {
@@ -61,13 +61,13 @@
         font-size: var(--typography-size-100);
         margin-top: var(--space-xl);
         padding-top: var(--space-m);
-        display: grid;
-        gap: var(--space-s);
+
+        @include grid-stack(var(--space-s));
     }
 
     .article :global(.footnotes ol) {
-        display: grid;
-        gap: var(--space-xs);
+        @include grid-stack(var(--space-xs));
+
         margin: 0;
         padding-left: var(--space-2xl);
     }

--- a/app/articles/page.module.scss
+++ b/app/articles/page.module.scss
@@ -2,9 +2,7 @@
 
 @layer components {
     .heading {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+        @include flex-between;
     }
 
     .heading a {

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -1,3 +1,5 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .card {
         background: var(--surface-level-1);
@@ -50,10 +52,7 @@
     }
 
     .head {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: var(--space-s);
+        @include flex-between(flex-start, var(--space-s));
     }
 
     .head h3,

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -1,3 +1,5 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .header {
         position: sticky;
@@ -12,9 +14,8 @@
     }
 
     .inner {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
+        @include flex-between;
+
         padding-block: var(--space-m);
         transition: padding var(--motion-dur-200) var(--motion-ease-standard);
     }

--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -1,3 +1,5 @@
+@use "../../styles/mixins" as *;
+
 @layer components {
     .toc {
         max-width: calc(var(--typography-measure) / 2);
@@ -10,8 +12,9 @@
 
     .list {
         margin: 0;
-        display: grid;
-        gap: var(--space-xs);
+
+        @include grid-stack(var(--space-xs));
+
         font-size: var(--typography-size-100);
     }
 

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -72,6 +72,16 @@
     justify-content: center;
 }
 
+@mixin flex-between($align: center, $gap: null) {
+    display: flex;
+    justify-content: space-between;
+    align-items: $align;
+
+    @if $gap != null {
+        gap: $gap;
+    }
+}
+
 @mixin centered-list($gap, $wrap: false) {
     list-style: none;
     padding: 0;
@@ -85,8 +95,13 @@
     }
 }
 
-@mixin card-grid($gap: var(--space-xl)) {
+@mixin grid-stack($gap: var(--space-m)) {
     display: grid;
     gap: $gap;
+}
+
+@mixin card-grid($gap: var(--space-xl)) {
+    @include grid-stack($gap);
+
     margin-block-start: var(--space-l);
 }


### PR DESCRIPTION
## Summary
- add generic `grid-stack` mixin and reuse in grid layouts
- add `flex-between` mixin for spaced flex containers
- fix stylelint formatting after refactor

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a25d5868c88328ac143ecd017da346