### PR TITLE
refactor: rely on metadata for head tags

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -100,18 +100,6 @@ export default function RootLayout({
                     name="apple-mobile-web-app-title"
                     content={METADATA.brand}
                 />
-                <meta name="color-scheme" content="light dark" />
-                <meta
-                    name="theme-color"
-                    media="(prefers-color-scheme: light)"
-                    content={METADATA.theme.light}
-                />
-                <meta
-                    name="theme-color"
-                    media="(prefers-color-scheme: dark)"
-                    content={METADATA.theme.dark}
-                />
-                <meta name="description" content={METADATA.description} />
                 <link
                     rel="preconnect"
                     href="https://fonts.gstatic.com"


### PR DESCRIPTION
## Summary
- remove manual description, color-scheme, and theme-color meta tags
- rely on exported metadata and viewport for head metadata

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a300d8f45c8328bd54b171053574fb