### PR TITLE
Disable dynamic route params for article pages

### DIFF
--- a/app/articles/[year]/[slug]/opengraph-image.tsx
+++ b/app/articles/[year]/[slug]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from "next/og";
 import { getAllArticles, getArticle } from "@/lib/articles";
 
 export const dynamic = "force-static";
+export const dynamicParams = false;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/app/articles/[year]/[slug]/page.tsx
+++ b/app/articles/[year]/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { formatDate } from "@/lib/date";
 import { buildArticleStructuredData } from "@/lib/structured-data";
 import styles from "./page.module.scss";
 
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
     const articles = await getAllArticles();
     return articles.map(({ year, slug }) => ({ year, slug }));

--- a/app/articles/[year]/[slug]/twitter-image.tsx
+++ b/app/articles/[year]/[slug]/twitter-image.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from "next/og";
 import { getAllArticles, getArticle } from "@/lib/articles";
 
 export const dynamic = "force-static";
+export const dynamicParams = false;
 export const size = { width: 1600, height: 900 };
 export const contentType = "image/png";
 


### PR DESCRIPTION
## Summary
- prevent dynamic route params for article pages and images

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers` *(fails: network or environment constraints)*
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a301565d248328849616c5056b47cf