### PR TITLE
Fix Storybook font variable layering

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,24 +5,30 @@ import "../styles/globals.scss";
 import "../styles/typography.scss";
 
 const header = Lexend_Deca({
-    variable: "--font-header",
     subsets: ["latin"],
     display: "swap",
 });
 
 const body = Roboto_Mono({
-    variable: "--font-body",
     subsets: ["latin"],
     display: "swap",
 });
 
-export const decorators: Decorator[] = [
-    (Story) => (
-        <div className={`${header.variable} ${body.variable}`}>
-            <Story />
-        </div>
-    ),
-];
+const withFontVariables: Decorator = (Story) => (
+    <>
+        <style>
+            {`
+                :root {
+                    --font-header: ${header.style.fontFamily};
+                    --font-body: ${body.style.fontFamily};
+                }
+            `}
+        </style>
+        <Story />
+    </>
+);
+
+export const decorators: Decorator[] = [withFontVariables];
 
 const preview: Preview = {
     parameters: {


### PR DESCRIPTION
## Summary
- inject Storybook font variables into `:root` via inline style so paragraph text uses the correct family

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31aed011c83289447347327632f8b