### PR TITLE
Improve Safari animation performance

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -3,12 +3,12 @@
 @keyframes fade-in-up {
     from {
         opacity: 0;
-        transform: translateY(var(--space-m));
+        transform: translate3d(0, var(--space-m), 0);
     }
 
     to {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate3d(0, 0, 0);
         visibility: visible;
     }
 }
@@ -72,10 +72,11 @@
         .heroIntro,
         .cta {
             opacity: 0;
-            transform: translateY(var(--space-m));
+            transform: translate3d(0, var(--space-m), 0);
             visibility: hidden;
             animation: fade-in-up var(--motion-dur-320)
                 var(--motion-ease-emphasized) forwards;
+            will-change: opacity, transform;
         }
 
         .availability {


### PR DESCRIPTION
## Summary
- use hardware-accelerated 3D transforms in hero animations
- hint Safari to optimize hero animations with `will-change`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a35cb6565c8328b8c62b26c0d26a68