### PR TITLE
fix: ensure hero background renders in Safari

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -128,12 +128,12 @@ export default function RootLayout({
                         <radialGradient id="b" cx="20%" cy="25%" r="60%">
                             <stop
                                 offset="0%"
-                                stopColor="var(--colour-primary)"
+                                style={{ stopColor: "var(--colour-primary)" }}
                                 stopOpacity=".25"
                             />
                             <stop
                                 offset="100%"
-                                stopColor="var(--colour-primary)"
+                                style={{ stopColor: "var(--colour-primary)" }}
                                 stopOpacity="0"
                             />
                         </radialGradient>
@@ -177,13 +177,13 @@ export default function RootLayout({
                         >
                             <path
                                 fill="none"
-                                stroke="var(--colour-border)"
+                                style={{ stroke: "var(--colour-border)" }}
                                 strokeOpacity=".25"
                                 d="M64 0H0v64"
                             />
                             <path
                                 fill="none"
-                                stroke="var(--colour-border)"
+                                style={{ stroke: "var(--colour-border)" }}
                                 strokeOpacity=".15"
                                 d="M32 0v64M0 32h64"
                             />
@@ -195,7 +195,7 @@ export default function RootLayout({
                     <rect
                         width="100%"
                         height="100%"
-                        fill="var(--surface-level-0)"
+                        style={{ fill: "var(--surface-level-0)" }}
                     />
                     <rect width="100%" height="100%" fill="url(#b)" />
                     <rect width="100%" height="100%" fill="url(#c)" />


### PR DESCRIPTION
## Summary
- fix hero SVG color attributes to use inline styles, displaying background correctly in Safari

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38b3e34a88328905afc5293f74232