### PR TITLE
Disable content visibility to fix Safari animation lag

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -15,7 +15,6 @@ export default function Hero() {
             className={styles.hero}
             labelledBy="hero-heading"
             containerSize="l"
-            contentVisibility={false}
         >
             <div className={styles.availability}>
                 <p>

--- a/components/Section/Section.stories.tsx
+++ b/components/Section/Section.stories.tsx
@@ -87,6 +87,6 @@ export const WithoutHeading: Story = {
     args: { heading: undefined },
 };
 
-export const ContentVisibilityOff: Story = {
-    args: { contentVisibility: false },
+export const ContentVisibilityOn: Story = {
+    args: { contentVisibility: true },
 };

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -10,6 +10,10 @@ interface Props {
     className?: string;
     containerSize?: "s" | "m" | "l";
     style?: CSSProperties;
+    /**
+     * Enables `content-visibility: auto` for this section.
+     * Disabled by default due to Safari animation issues.
+     */
     contentVisibility?: boolean;
     children: ReactNode;
 }
@@ -23,7 +27,7 @@ export default function Section({
     className,
     containerSize,
     style,
-    contentVisibility = true,
+    contentVisibility = false,
     children,
 }: Props) {
     const sectionStyle = contentVisibility


### PR DESCRIPTION
## Summary
- disable `content-visibility` in Section component by default
- drop explicit `contentVisibility` prop from Hero
- update Section stories for new default

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38f2c1d5c8328a07b51fedfadd935