### PR TITLE
fix: improve Safari animation and theme transitions

### DIFF
--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -3,13 +3,12 @@
 @keyframes fade-in-up {
     from {
         opacity: 0;
-        transform: translate3d(0, var(--space-m), 0);
+        transform: translateY(var(--space-m));
     }
 
     to {
         opacity: 1;
-        transform: translate3d(0, 0, 0);
-        visibility: visible;
+        transform: translateY(0);
     }
 }
 
@@ -71,11 +70,9 @@
     .heroIntro,
     .cta {
         opacity: 0;
-        transform: translate3d(0, var(--space-m), 0);
-        visibility: hidden;
+        transform: translateY(var(--space-m));
         animation: fade-in-up var(--motion-dur-320)
-            var(--motion-ease-emphasized) forwards;
-        will-change: opacity, transform;
+            var(--motion-ease-emphasized) both;
     }
 
     .availability {

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -24,11 +24,12 @@ html {
 }
 
 body {
-    background: var(--surface-level-0);
+    background-color: var(--surface-level-0);
     color: var(--colour-text);
     transition:
-        background var(--motion-dur-200) var(--motion-ease-standard),
+        background-color var(--motion-dur-200) var(--motion-ease-standard),
         color var(--motion-dur-200) var(--motion-ease-standard);
+    will-change: background-color, color;
     display: flex;
     flex-direction: column;
     min-block-size: 100vh;


### PR DESCRIPTION
## Summary
- smooth hero animation by removing 3D transforms and visibility hacks
- optimize theme colour changes using `background-color` and `will-change`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a3976545388328a9bcf957ed3044bf