### PR TITLE
chore: replace deprecated sass imports

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,10 +1,11 @@
+@use "sass:meta";
 @layer base, tokens;
 
 @layer base {
-    @import "base";
-    @import "typography";
+    @include meta.load-css("base");
+    @include meta.load-css("typography");
 }
 
 @layer tokens {
-    @import "tokens";
+    @include meta.load-css("tokens");
 }


### PR DESCRIPTION
## Summary
- replace deprecated `@import` directives with `meta.load-css` using `@use`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: accessibility check violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a451ef247c8328b8ce46308f599c59