### PR TITLE
refactor: use border width design tokens

### DIFF
--- a/app/articles/[year]/[slug]/page.module.scss
+++ b/app/articles/[year]/[slug]/page.module.scss
@@ -27,7 +27,7 @@
 .article :global(blockquote) {
     margin: 0;
     padding: var(--space-m) var(--space-l);
-    border: 4px solid var(--colour-text-subtle);
+    border: var(--border-width-l) solid var(--colour-text-subtle);
     background: var(--surface-level-1);
     border-radius: var(--radius-m);
 }

--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -3,7 +3,7 @@
 .button {
     @include inline-center;
 
-    border: 1px solid transparent;
+    border: var(--border-width-s) solid transparent;
     cursor: pointer;
     font: inherit;
     font-family: var(--font-header), sans-serif;

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -21,7 +21,7 @@
 }
 
 .card[data-highlight] {
-    border: 2px solid var(--colour-primary);
+    border: var(--border-width-m) solid var(--colour-primary);
 }
 
 .card:focus-within {

--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -5,7 +5,7 @@
 
     margin-block-start: auto;
     padding-block: var(--space-xl);
-    border-block-start: 1px solid var(--colour-border);
+    border-block-start: var(--border-width-s) solid var(--colour-border);
     font-size: var(--typography-size-100);
     text-align: center;
     color: var(--colour-text-subtle);

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -4,7 +4,7 @@
     position: sticky;
     inset-block-start: 0;
     background: transparent;
-    border-block-end: 1px solid transparent;
+    border-block-end: var(--border-width-s) solid transparent;
     z-index: var(--z-2);
     transition:
         background var(--motion-dur-200) var(--motion-ease-standard),

--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -3,7 +3,7 @@
 .toc {
     max-width: calc(var(--typography-measure) / 2);
     padding: var(--space-m);
-    border: 1px solid var(--colour-border);
+    border: var(--border-width-s) solid var(--colour-border);
     border-radius: var(--radius-m);
     background: var(--surface-level-1);
     margin-block: var(--space-xl);

--- a/styles/_tokens.scss
+++ b/styles/_tokens.scss
@@ -83,6 +83,11 @@
     --radius-xl: 24px;
     --radius-2xl: 36px;
 
+    /* border width */
+    --border-width-s: 1px;
+    --border-width-m: 2px;
+    --border-width-l: 4px;
+
     /* shadows */
     --shadow-elev-1: 0 1px 2px hsl(0deg 0% 0% / 5%);
     --shadow-elev-2:
@@ -117,7 +122,7 @@
     --z-3: 1000; /* overlays */
 
     /* focus */
-    --border-focus-ring: 2px solid var(--colour-primary);
+    --border-focus-ring: var(--border-width-m) solid var(--colour-primary);
     --space-focus-ring-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- add border width design tokens
- replace hardcoded border widths in Button, Header, Footer, Table of Contents, Card, and article blockquotes

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46c891204832897955a3368a809d5