### PR TITLE
feat: enrich frontend platform article

### DIFF
--- a/content/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas.mdx
+++ b/content/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas.mdx
@@ -80,6 +80,18 @@ Architecting a frontend platform with all these layers of discipline might seem 
 
 In sum, the investment in a scalable frontend platform yields dividends in compliance assurance, faster delivery of features, easier onboarding, and less wasteful work.
 
+## Case Insights - Building a KYC/AML SaaS Frontend, Lessons from the Trenches
+
+Drawing from my experience building a greenfield KYC/AML SaaS platform's frontend, a few real-world insights illustrate how the principles above come together:
+
+- **Design System as a Compliance Enforcer**: A consent component logged every agreement with a version stamp and timestamp so auditors could trace exactly what a user saw and accepted. Centralising this in the design system meant no team could ship a flow without the required logging.
+- **Shared API Models Killed Entire Categories of Bugs**: By generating TypeScript types from a single OpenAPI source of truth, mismatched field names like `customerId` vs. `customer_id` simply couldn't compile, eliminating an entire class of integration defects.
+- **Onboarding via "Quality Gates Passport"**: New engineers completed a checklist that guided them through linting, Storybook, and accessibility tooling. This made platform conventions second nature and prevented accidental bypassing of established checks.
+- **Entity Filtering Hook in Context**: Refactoring a complex AML alert list into a `useAlertFilters` hook backed by context removed duplicated state logic and made adding new filters trivial.[^12]
+- **React Hook Form + Zod in Practice**: Multi-step onboarding forms used `react-hook-form` with Zod schemas to validate inputs like ID document numbers client-side and server-side, reducing support tickets from invalid submissions.[^9] [^14]
+
+In all these cases, a bit of upfront investment in shared logic or architecture paid off by simplifying future work and reducing errors. The insights may seem small in isolation, but together they demonstrate how disciplined frontend engineering directly supports compliance and developer velocity.
+
 ## Future Outlook - AI-Assisted Tooling and Agentic Workflows on the Horizon
 
 As we look forward, one exciting frontier for frontend platforms is the incorporation of AI-assisted tooling and "agentic" workflows. The idea is that many of the tasks we now handle through manual effort or static scripts could be offloaded to intelligent agents.

--- a/tests/articles.spec.ts
+++ b/tests/articles.spec.ts
@@ -27,3 +27,32 @@ test("article page is accessible", async ({ page }) => {
         .analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
 });
+
+test("scaling frontend article has correct metadata and is accessible", async ({
+    page,
+}) => {
+    await page.goto(
+        "/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas",
+    );
+    await expect(page.locator("article")).toBeVisible();
+    await expect(
+        page.locator('nav[aria-labelledby="toc-heading"]'),
+    ).toBeVisible();
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+        "href",
+        "https://lapidist.net/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas/",
+    );
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+        "content",
+        "Architecting a Modern Frontend Platform: Scaling React, TypeScript, and API Contracts in Regulated SaaS",
+    );
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+        "content",
+        "summary_large_image",
+    );
+    const accessibilityScanResults = await new AxeBuilder({ page })
+        .include("main")
+        .exclude('[role="alert"]')
+        .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+});

--- a/tests/sitemap.spec.ts
+++ b/tests/sitemap.spec.ts
@@ -1,18 +1,25 @@
 import { expect, test } from "@playwright/test";
 
 test("sitemap URLs match canonical URLs", async ({ request }) => {
-    const articlePath =
-        "/articles/2025/what-recovering-from-a-stroke-at-34-taught-me/";
-    const articleUrl = `https://lapidist.net${articlePath}`;
+    const articlePaths = [
+        "/articles/2025/what-recovering-from-a-stroke-at-34-taught-me/",
+        "/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas/",
+    ];
 
     const sitemapResponse = await request.get("/sitemap.xml");
     expect(sitemapResponse.ok()).toBeTruthy();
     const xml = await sitemapResponse.text();
-    expect(xml).toContain(articleUrl);
 
-    const articleResponse = await request.get(articlePath);
-    expect(articleResponse.ok()).toBeTruthy();
-    const html = await articleResponse.text();
-    const canonicalMatch = html.match(/<link rel="canonical" href="([^"]+)"/);
-    expect(canonicalMatch?.[1]).toBe(articleUrl);
+    for (const articlePath of articlePaths) {
+        const articleUrl = `https://lapidist.net${articlePath}`;
+        expect(xml).toContain(articleUrl);
+
+        const articleResponse = await request.get(articlePath);
+        expect(articleResponse.ok()).toBeTruthy();
+        const html = await articleResponse.text();
+        const canonicalMatch = html.match(
+            /<link rel="canonical" href="([^"]+)"/,
+        );
+        expect(canonicalMatch?.[1]).toBe(articleUrl);
+    }
 });


### PR DESCRIPTION
## Summary
- add case study insights to regulated SaaS frontend article
- test metadata & sitemap for new article

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a483d023488328972392be94350414