### PR TITLE
fix: update key takeaways count

### DIFF
--- a/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
+++ b/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
@@ -80,7 +80,7 @@ Before my stroke, I was laser-focused on technical excellence: writing clean cod
 
 ## Practical takeaways for engineers and leaders
 
-Finally, I want to distill everything I've learned into a few actionable insights. Whether you're an individual contributor or a team lead, here are five key takeaways from my journey:
+Finally, I want to distill everything I've learned into a few actionable insights. Whether you're an individual contributor or a team lead, here are four key takeaways from my journey:
 
 1. **Rest is strategic.** High performance in software engineering is not about constant grind; it's about smart recovery cycles. Treat sleep, breaks, and time off as essential parts of your workflow - they will make your code and decisions better, not worse.
 2. **Stress compounds silently.** Unchecked stress accumulates over time. Don't wait until you hit a wall; start implementing stress-reduction habits at the first warning signs. It's much easier to course-correct early than recover from a total collapse.


### PR DESCRIPTION
## Summary
- fix article to mention four key takeaways instead of five

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a044bd0c8328a81a3327b22f3f7f