### PR TITLE
Use feed library for Atom RSS feed

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,3 +1,4 @@
+import { Feed } from "feed";
 import { getAllArticles } from "@/lib/articles";
 
 const BASE_URL = "https://lapidist.net";
@@ -8,34 +9,36 @@ const SITE_DESCRIPTION =
 
 export const dynamic = "force-static";
 
-function escapeHtml(str: string) {
-    return str
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
-}
-
 export async function GET() {
     const articles = await getAllArticles();
-    const items = articles
-        .map(
-            ({ title, description, year, slug, date }) =>
-                `\n        <item>\n            <title>${escapeHtml(title)}</title>\n            <description>${escapeHtml(description)}</description>\n            <link>${BASE_URL}/articles/${year}/${slug}/</link>\n            <guid>${BASE_URL}/articles/${year}/${slug}/</guid>\n            <pubDate>${new Date(date).toUTCString()}</pubDate>\n        </item>`,
-        )
-        .join("");
 
-    const lastBuildDate =
-        articles.length > 0
-            ? new Date(articles[0].date).toUTCString()
-            : new Date().toUTCString();
+    const feed = new Feed({
+        title: SITE_TITLE,
+        description: SITE_DESCRIPTION,
+        id: BASE_URL,
+        link: BASE_URL,
+        language: "en-GB",
+        image: `${BASE_URL}/opengraph-image`,
+        copyright: `${String(new Date().getFullYear())} Brett Dorrans`,
+        updated: articles.length > 0 ? new Date(articles[0].date) : new Date(),
+    });
 
-    const rss = `<?xml version="1.0" encoding="UTF-8" ?>\n<rss version="2.0">\n    <channel>\n        <title>${escapeHtml(SITE_TITLE)}</title>\n        <link>${BASE_URL}</link>\n        <description>${escapeHtml(SITE_DESCRIPTION)}</description>\n        <language>en-GB</language>\n        <lastBuildDate>${lastBuildDate}</lastBuildDate>\n        <image>\n            <url>${BASE_URL}/opengraph-image</url>\n            <title>${escapeHtml(SITE_TITLE)}</title>\n            <link>${BASE_URL}</link>\n        </image>${items}\n    </channel>\n</rss>`;
+    articles.forEach(({ title, description, year, slug, date, author }) => {
+        feed.addItem({
+            title,
+            id: `${BASE_URL}/articles/${year}/${slug}/`,
+            link: `${BASE_URL}/articles/${year}/${slug}/`,
+            description,
+            author: author.name
+                ? [{ name: author.name, link: author.url }]
+                : undefined,
+            date: new Date(date),
+        });
+    });
 
-    return new Response(rss, {
+    return new Response(feed.atom1(), {
         headers: {
-            "Content-Type": "application/rss+xml; charset=utf-8",
+            "Content-Type": "application/atom+xml; charset=utf-8",
         },
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@lapidist/cv-generator": "2.4.0",
                 "clsx": "2.1.1",
+                "feed": "^4.2.2",
                 "github-slugger": "^2.0.0",
                 "gray-matter": "4.0.3",
                 "mdast-util-to-string": "^4.0.0",
@@ -11863,6 +11864,18 @@
                 "pend": "~1.2.0"
             }
         },
+        "node_modules/feed": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+            "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+            "license": "MIT",
+            "dependencies": {
+                "xml-js": "^1.6.11"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/figures": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -18786,6 +18799,12 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/sax": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+            "license": "ISC"
+        },
         "node_modules/scheduler": {
             "version": "0.26.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -21741,6 +21760,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/xml-js": {
+            "version": "1.6.11",
+            "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+            "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "xml-js": "bin/cli.js"
             }
         },
         "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@lapidist/cv-generator": "2.4.0",
         "clsx": "2.1.1",
+        "feed": "^4.2.2",
         "github-slugger": "^2.0.0",
         "gray-matter": "4.0.3",
         "mdast-util-to-string": "^4.0.0",


### PR DESCRIPTION
## Summary
- generate RSS feed using the `feed` library
- output Atom XML instead of manually constructed RSS

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b060e9688328a1eecfd7bfe76057