### PR TITLE
feat: expand sitemap entries with last modified

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,26 +1,72 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
 import type { MetadataRoute } from "next";
 import { getAllArticles } from "@/lib/articles";
 
 export const dynamic = "force-static";
 
+function getLastModifiedDate(filePath: string): Date {
+    try {
+        const gitDate = execSync(`git log -1 --format=%cI -- ${filePath}`, {
+            cwd: process.cwd(),
+            encoding: "utf8",
+        }).trim();
+        if (gitDate) {
+            return new Date(gitDate);
+        }
+    } catch {
+        // ignore
+    }
+    try {
+        const { mtime } = fs.statSync(path.join(process.cwd(), filePath));
+        return mtime;
+    } catch {
+        // ignore
+    }
+    return new Date();
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const articles = await getAllArticles();
-    const articleEntries = articles.map(({ year, slug, date }) => ({
-        url: `https://lapidist.net/articles/${year}/${slug}/`,
-        lastModified: new Date(date),
-    }));
+    const articleEntries = articles.map(({ year, slug }) => {
+        let filePath = path.join("content", "articles", year, `${slug}.mdx`);
+        if (!fs.existsSync(path.join(process.cwd(), filePath))) {
+            filePath = path.join("content", "articles", year, `${slug}.md`);
+        }
+        return {
+            url: `https://lapidist.net/articles/${year}/${slug}/`,
+            lastModified: getLastModifiedDate(filePath),
+        };
+    });
     return [
         {
             url: "https://lapidist.net/",
-            lastModified: new Date(),
+            lastModified: getLastModifiedDate("app/page.tsx"),
         },
         {
             url: "https://lapidist.net/about/",
-            lastModified: new Date(),
+            lastModified: getLastModifiedDate("app/about/page.tsx"),
         },
         {
             url: "https://lapidist.net/articles/",
-            lastModified: new Date(),
+            lastModified: getLastModifiedDate("app/articles/page.tsx"),
+        },
+        {
+            url: "https://lapidist.net/accessibility-statement/",
+            lastModified: getLastModifiedDate(
+                "app/accessibility-statement/page.tsx",
+            ),
+        },
+        {
+            url: "https://lapidist.net/ai-ethics-statement/",
+            lastModified: getLastModifiedDate(
+                "app/ai-ethics-statement/page.tsx",
+            ),
+        },
+        {
+            url: "https://lapidist.net/brett-dorrans-cv.pdf",
+            lastModified: getLastModifiedDate("public/brett-dorrans-cv.pdf"),
         },
         ...articleEntries,
     ];


### PR DESCRIPTION
## Summary
- include accessibility, AI ethics, and CV asset pages in sitemap
- derive sitemap lastModified values from git metadata or file mtimes

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50aba6c208328b87f223d12e52586