### PR TITLE
feat: add Prism syntax highlighting for MDX

### DIFF
--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -6,6 +6,7 @@ import matter from "gray-matter";
 import type { Heading as MdastHeading, Root } from "mdast";
 import { toString } from "mdast-util-to-string";
 import { compileMDX } from "next-mdx-remote/rsc";
+import rehypePrism from "rehype-prism-plus";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import readingTime from "remark-reading-time";
@@ -62,7 +63,10 @@ export const getArticle = cache(async (year: string, slug: string) => {
     const { content: MDXContent } = await compileMDX({
         source: content,
         options: {
-            mdxOptions: { remarkPlugins: [remarkGfm, headingPlugin] },
+            mdxOptions: {
+                remarkPlugins: [remarkGfm, headingPlugin],
+                rehypePlugins: [rehypePrism],
+            },
         },
     });
     const meta: ArticleMeta = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,12 @@
+import createMDX from "@next/mdx";
 import type { NextConfig } from "next";
+import rehypePrism from "rehype-prism-plus";
+
+const withMDX = createMDX({
+    options: {
+        rehypePlugins: [rehypePrism],
+    },
+});
 
 const nextConfig: NextConfig = {
     output: "export",
@@ -6,6 +14,7 @@ const nextConfig: NextConfig = {
     images: {
         unoptimized: true,
     },
+    pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
 };
 
-export default nextConfig;
+export default withMDX(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@lapidist/cv-generator": "2.4.0",
+                "@next/mdx": "^15.5.0",
                 "clsx": "2.1.1",
                 "feed": "^5.0.0",
                 "github-slugger": "^2.0.0",
@@ -18,8 +19,10 @@
                 "next": "15.5.0",
                 "next-mdx-remote": "5.0.0",
                 "prettier": "3.6.2",
+                "prismjs": "^1.30.0",
                 "react": "19.1.1",
                 "react-dom": "19.1.1",
+                "rehype-prism-plus": "^2.0.1",
                 "remark": "^15.0.1",
                 "remark-gfm": "^4.0.1",
                 "remark-reading-time": "^2.0.2",
@@ -4179,6 +4182,27 @@
                 "fast-glob": "3.3.1"
             }
         },
+        "node_modules/@next/mdx": {
+            "version": "15.5.0",
+            "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.0.tgz",
+            "integrity": "sha512-TxfWpIDHx9Xy/GgZwegrl+HxjzeQml0bTclxX72SqJLi83IhJaFiglQbfMTotB2hDRbxCGKpPYh0X20+r1Trtw==",
+            "license": "MIT",
+            "dependencies": {
+                "source-map": "^0.7.0"
+            },
+            "peerDependencies": {
+                "@mdx-js/loader": ">=0.15.0",
+                "@mdx-js/react": ">=0.15.0"
+            },
+            "peerDependenciesMeta": {
+                "@mdx-js/loader": {
+                    "optional": true
+                },
+                "@mdx-js/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@next/swc-darwin-arm64": {
             "version": "15.5.0",
             "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.0.tgz",
@@ -6595,6 +6619,12 @@
             "dependencies": {
                 "@types/pg": "*"
             }
+        },
+        "node_modules/@types/prismjs": {
+            "version": "1.26.5",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+            "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+            "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "19.1.10",
@@ -12737,6 +12767,102 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hast-util-from-html": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+            "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "devlop": "^1.1.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "parse5": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "devlop": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-location": "^5.0.0",
+                "web-namespaces": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5/node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5/node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+            "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector/node_modules/@types/hast": {
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+            "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2"
+            }
+        },
+        "node_modules/hast-util-parse-selector/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
         "node_modules/hast-util-to-estree": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -12792,6 +12918,19 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hast-util-to-string": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+            "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-whitespace": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -12803,6 +12942,48 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+            "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^2.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^3.0.0",
+                "property-information": "^6.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript/node_modules/@types/hast": {
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+            "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2"
+            }
+        },
+        "node_modules/hastscript/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
+        "node_modules/hastscript/node_modules/property-information": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+            "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/he": {
@@ -16773,11 +16954,41 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-numeric-range": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+            "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+            "license": "ISC"
+        },
         "node_modules/parse-svg-path": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
             "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
             "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
@@ -17478,6 +17689,15 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/prismjs": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -18035,6 +18255,37 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/refractor": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.9.0.tgz",
+            "integrity": "sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^2.0.0",
+                "@types/prismjs": "^1.0.0",
+                "hastscript": "^7.0.0",
+                "parse-entities": "^4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/refractor/node_modules/@types/hast": {
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+            "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2"
+            }
+        },
+        "node_modules/refractor/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
         "node_modules/regenerate": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -18132,6 +18383,35 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/rehype-parse": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+            "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-from-html": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-prism-plus": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.1.tgz",
+            "integrity": "sha512-Wglct0OW12tksTUseAPyWPo3srjBOY7xKlql/DPKi7HbsdZTyaLCAoO58QBKSczFQxElTsQlOY3JDOFzB/K++Q==",
+            "license": "MIT",
+            "dependencies": {
+                "hast-util-to-string": "^3.0.0",
+                "parse-numeric-range": "^1.3.0",
+                "refractor": "^4.8.0",
+                "rehype-parse": "^9.0.0",
+                "unist-util-filter": "^5.0.0",
+                "unist-util-visit": "^5.0.0"
             }
         },
         "node_modules/rehype-recma": {
@@ -20975,6 +21255,31 @@
                 "node": ">=8"
             }
         },
+        "node_modules/unist-util-filter": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
+            "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            }
+        },
+        "node_modules/unist-util-filter/node_modules/unist-util-visit-parents": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+            "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/unist-util-is": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
@@ -21311,6 +21616,20 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/vfile-location": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/vfile-matter": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
@@ -21404,6 +21723,16 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/web-namespaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+            "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     },
     "dependencies": {
         "@lapidist/cv-generator": "2.4.0",
+        "@next/mdx": "^15.5.0",
         "clsx": "2.1.1",
         "feed": "^5.0.0",
         "github-slugger": "^2.0.0",
@@ -44,8 +45,10 @@
         "next": "15.5.0",
         "next-mdx-remote": "5.0.0",
         "prettier": "3.6.2",
+        "prismjs": "^1.30.0",
         "react": "19.1.1",
         "react-dom": "19.1.1",
+        "rehype-prism-plus": "^2.0.1",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-reading-time": "^2.0.2",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,4 +1,6 @@
 @use "sass:meta";
+/* stylelint-disable-next-line no-invalid-position-at-import-rule */
+@import "prismjs/themes/prism-tomorrow.css";
 @layer base, tokens;
 
 @layer base {


### PR DESCRIPTION
## Summary
- add Prism-based syntax highlighting for MDX content
- register MDX with `rehype-prism-plus` and extend Next.js page extensions
- load Prism Tomorrow theme in global styles

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5df17984c83289615cb9abba465d1