### PR TITLE
fix: remove MDX loader options

### DIFF
--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -6,7 +6,7 @@ import matter from "gray-matter";
 import type { Heading as MdastHeading, Root } from "mdast";
 import { toString } from "mdast-util-to-string";
 import { compileMDX } from "next-mdx-remote/rsc";
-import rehypePrism from "rehype-prism-plus";
+import rehypePrismPlus from "rehype-prism-plus";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import readingTime from "remark-reading-time";
@@ -65,7 +65,7 @@ export const getArticle = cache(async (year: string, slug: string) => {
         options: {
             mdxOptions: {
                 remarkPlugins: [remarkGfm, headingPlugin],
-                rehypePlugins: [rehypePrism],
+                rehypePlugins: [rehypePrismPlus],
             },
         },
     });

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,4 @@
-import createMDX from "@next/mdx";
 import type { NextConfig } from "next";
-import rehypePrism from "rehype-prism-plus";
-
-const withMDX = createMDX({
-    options: {
-        rehypePlugins: [rehypePrism],
-    },
-});
 
 const nextConfig: NextConfig = {
     output: "export",
@@ -14,7 +6,6 @@ const nextConfig: NextConfig = {
     images: {
         unoptimized: true,
     },
-    pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
 };
 
-export default withMDX(nextConfig);
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@lapidist/cv-generator": "2.4.0",
-                "@next/mdx": "^15.5.0",
                 "clsx": "2.1.1",
                 "feed": "^5.0.0",
                 "github-slugger": "^2.0.0",
@@ -4180,27 +4179,6 @@
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "3.3.1"
-            }
-        },
-        "node_modules/@next/mdx": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.0.tgz",
-            "integrity": "sha512-TxfWpIDHx9Xy/GgZwegrl+HxjzeQml0bTclxX72SqJLi83IhJaFiglQbfMTotB2hDRbxCGKpPYh0X20+r1Trtw==",
-            "license": "MIT",
-            "dependencies": {
-                "source-map": "^0.7.0"
-            },
-            "peerDependencies": {
-                "@mdx-js/loader": ">=0.15.0",
-                "@mdx-js/react": ">=0.15.0"
-            },
-            "peerDependenciesMeta": {
-                "@mdx-js/loader": {
-                    "optional": true
-                },
-                "@mdx-js/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@next/swc-darwin-arm64": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     },
     "dependencies": {
         "@lapidist/cv-generator": "2.4.0",
-        "@next/mdx": "^15.5.0",
         "clsx": "2.1.1",
         "feed": "^5.0.0",
         "github-slugger": "^2.0.0",


### PR DESCRIPTION
## Summary
- inline Prism syntax highlighting plugin during article compilation
- drop unused `@next/mdx` dependency and revert Next.js config
- ensure Prism plugin is applied directly in `articles.ts`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers` *(aborted: large system packages required)*
- `npm test` *(fails: web server exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a613ff82588328a590ff5db12c5ab9