### PR TITLE
feat: add accessible audio player

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
     stories: ["../**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-    addons: [],
+    addons: ["@storybook/addon-a11y"],
     framework: {
         name: "@storybook/nextjs",
         options: {},

--- a/components/AudioPlayer/AudioPlayer.module.scss
+++ b/components/AudioPlayer/AudioPlayer.module.scss
@@ -1,0 +1,43 @@
+@use "../../styles/mixins" as *;
+
+.player {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+}
+
+.controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+}
+
+.play {
+    @include inline-center;
+
+    padding: var(--space-xs);
+}
+
+.icon {
+    inline-size: var(--size-icon-m);
+    block-size: var(--size-icon-m);
+    fill: currentcolor;
+}
+
+.slider {
+    flex: 1;
+    accent-color: var(--colour-primary);
+}
+
+.time {
+    font-variant-numeric: tabular-nums;
+}
+
+.waveform {
+    inline-size: 100%;
+    block-size: var(--space-3xl);
+}
+
+.native {
+    display: none;
+}

--- a/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import AudioPlayer from "./AudioPlayer";
+
+const meta = {
+    title: "Components/AudioPlayer",
+    component: AudioPlayer,
+    parameters: {
+        a11y: { disable: false },
+    },
+} satisfies Meta<typeof AudioPlayer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        src: "/audio/sample.mp3",
+        title: "Sample audio",
+    },
+};
+
+export const WithWaveform: Story = {
+    args: {
+        src: "/audio/sample.mp3",
+        title: "Sample audio",
+        showWaveform: true,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        src: "/audio/sample.mp3",
+        title: "Sample audio",
+    },
+};
+
+export const Error: Story = {
+    args: {
+        src: "/audio/missing.mp3",
+        title: "Broken audio",
+    },
+};

--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type WaveSurfer from "wavesurfer.js";
+import Button from "@/components/Button/Button";
+import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
+import styles from "./AudioPlayer.module.scss";
+
+type Props = {
+    src: string;
+    title?: string;
+    showWaveform?: boolean;
+};
+
+export default function AudioPlayer({
+    src,
+    title,
+    showWaveform = false,
+}: Props) {
+    const audioRef = useRef<HTMLAudioElement | null>(null);
+    const waveformRef = useRef<HTMLDivElement | null>(null);
+    const waveSurferRef = useRef<WaveSurfer | null>(null);
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [duration, setDuration] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
+
+    const label = title ? `Audio player for ${title}` : "Audio player";
+
+    useEffect(() => {
+        if (showWaveform && typeof window !== "undefined") {
+            let cancelled = false;
+            void import("wavesurfer.js").then(
+                (module: typeof import("wavesurfer.js")) => {
+                    if (cancelled || !waveformRef.current) return;
+                    const ws = module.default.create({
+                        container: waveformRef.current,
+                        waveColor: "var(--surface-level-2)",
+                        progressColor: "var(--colour-primary)",
+                        cursorWidth: 0,
+                        url: src,
+                    });
+                    waveSurferRef.current = ws;
+                    ws.on("ready", () => {
+                        setDuration(ws.getDuration());
+                        setLoading(false);
+                    });
+                    ws.on("play", () => {
+                        setIsPlaying(true);
+                    });
+                    ws.on("pause", () => {
+                        setIsPlaying(false);
+                    });
+                    ws.on("timeupdate", () => {
+                        setCurrentTime(ws.getCurrentTime());
+                    });
+                    ws.on("error", () => {
+                        setError(true);
+                        setLoading(false);
+                    });
+                    ws.on("finish", () => {
+                        setIsPlaying(false);
+                    });
+                },
+            );
+            return () => {
+                cancelled = true;
+                waveSurferRef.current?.destroy();
+                waveSurferRef.current = null;
+            };
+        }
+
+        const audio = audioRef.current;
+        if (!audio) return;
+        const audioEl = audio;
+
+        function onLoadedMetadata() {
+            setDuration(audioEl.duration);
+            setLoading(false);
+        }
+        function onTimeUpdate() {
+            setCurrentTime(audioEl.currentTime);
+        }
+        function onEnded() {
+            setIsPlaying(false);
+        }
+        function onError() {
+            setError(true);
+            setLoading(false);
+        }
+
+        audioEl.addEventListener("loadedmetadata", onLoadedMetadata);
+        audioEl.addEventListener("timeupdate", onTimeUpdate);
+        audioEl.addEventListener("ended", onEnded);
+        audioEl.addEventListener("error", onError);
+
+        return () => {
+            audioEl.removeEventListener("loadedmetadata", onLoadedMetadata);
+            audioEl.removeEventListener("timeupdate", onTimeUpdate);
+            audioEl.removeEventListener("ended", onEnded);
+            audioEl.removeEventListener("error", onError);
+        };
+    }, [src, showWaveform]);
+
+    useEffect(() => {
+        if (!title) return;
+        if (typeof navigator === "undefined" || !("mediaSession" in navigator))
+            return;
+        navigator.mediaSession.metadata = new MediaMetadata({ title });
+    }, [title]);
+
+    function togglePlay() {
+        if (showWaveform && waveSurferRef.current) {
+            waveSurferRef.current.playPause();
+            setIsPlaying(waveSurferRef.current.isPlaying());
+        } else if (audioRef.current) {
+            if (audioRef.current.paused) {
+                void audioRef.current.play();
+                setIsPlaying(true);
+            } else {
+                audioRef.current.pause();
+                setIsPlaying(false);
+            }
+        }
+    }
+
+    function seek(value: number) {
+        if (showWaveform && waveSurferRef.current) {
+            waveSurferRef.current.setTime(value);
+        } else if (audioRef.current) {
+            audioRef.current.currentTime = value;
+        }
+        setCurrentTime(value);
+    }
+
+    function handleSliderChange(e: React.ChangeEvent<HTMLInputElement>) {
+        seek(Number(e.target.value));
+    }
+
+    const format = (t: number) => {
+        const minutes = Math.floor(t / 60)
+            .toString()
+            .padStart(2, "0");
+        const seconds = Math.floor(t % 60)
+            .toString()
+            .padStart(2, "0");
+        return `${minutes}:${seconds}`;
+    };
+
+    if (error) {
+        return (
+            <div className={styles.player} role="region" aria-label={label}>
+                <p role="alert">Audio failed to load.</p>
+                <noscript>
+                    <audio controls src={src}>
+                        <track
+                            kind="captions"
+                            src={src.replace(/\.[^/.]+$/, ".vtt")}
+                            label="Captions"
+                        />
+                    </audio>
+                </noscript>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.player} role="region" aria-label={label}>
+            {!showWaveform && (
+                <audio
+                    ref={audioRef}
+                    src={src}
+                    preload="metadata"
+                    className={styles.native}
+                    aria-hidden="true"
+                >
+                    <track
+                        kind="captions"
+                        src={src.replace(/\.[^/.]+$/, ".vtt")}
+                        label="Captions"
+                    />
+                </audio>
+            )}
+            {showWaveform && (
+                <div ref={waveformRef} className={styles.waveform} />
+            )}
+            {loading ? (
+                <p>Loading audio…</p>
+            ) : (
+                <div className={styles.controls}>
+                    <Button
+                        onClick={togglePlay}
+                        aria-pressed={isPlaying}
+                        className={styles.play}
+                        variant="secondary"
+                    >
+                        {isPlaying ? (
+                            <PauseIcon className={styles.icon} />
+                        ) : (
+                            <PlayIcon className={styles.icon} />
+                        )}
+                        <VisuallyHidden>
+                            {isPlaying ? "Pause audio" : "Play audio"}
+                        </VisuallyHidden>
+                    </Button>
+                    <input
+                        type="range"
+                        min={0}
+                        max={duration}
+                        step={0.1}
+                        value={currentTime}
+                        onChange={handleSliderChange}
+                        className={styles.slider}
+                        aria-label="Audio progress"
+                    />
+                    <span className={styles.time}>
+                        <VisuallyHidden>Elapsed time:</VisuallyHidden>
+                        {format(currentTime)} /
+                        <VisuallyHidden>Total time:</VisuallyHidden>
+                        {format(duration)}
+                    </span>
+                </div>
+            )}
+            <noscript>
+                <audio controls src={src}>
+                    <track
+                        kind="captions"
+                        src={src.replace(/\.[^/.]+$/, ".vtt")}
+                        label="Captions"
+                    />
+                </audio>
+            </noscript>
+        </div>
+    );
+}
+
+function PlayIcon(props: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+            <path d="M8 5v14l11-7z" />
+        </svg>
+    );
+}
+
+function PauseIcon(props: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+            <path d="M6 5h4v14H6zm8 0h4v14h-4z" />
+        </svg>
+    );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
                 "remark": "^15.0.1",
                 "remark-gfm": "^4.0.1",
                 "remark-reading-time": "^2.0.2",
-                "unist-util-visit": "^5.0.0"
+                "unist-util-visit": "^5.0.0",
+                "wavesurfer.js": "^7.7.11"
             },
             "devDependencies": {
                 "@axe-core/playwright": "4.10.2",
@@ -35,6 +36,7 @@
                 "@lhci/cli": "0.15.1",
                 "@next/eslint-plugin-next": "15.5.0",
                 "@playwright/test": "1.55.0",
+                "@storybook/addon-a11y": "9.1.2",
                 "@storybook/nextjs": "^9.1.1",
                 "@types/node": "24.3.0",
                 "@types/react": "19.1.10",
@@ -5849,6 +5851,24 @@
             "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
             "dev": true,
             "license": "BSD-3-Clause"
+        },
+        "node_modules/@storybook/addon-a11y": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-9.1.2.tgz",
+            "integrity": "sha512-CwFwpneZO8GvxaMygkNUEJ0ti2U6Q7waZ/NG71tRQzTWGMasbc27rUTvLf654mQen+MkSOt/MbceASkyvK2mdw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@storybook/global": "^5.0.0",
+                "axe-core": "^4.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "storybook": "^9.1.2"
+            }
         },
         "node_modules/@storybook/builder-webpack5": {
             "version": "9.1.2",
@@ -21702,6 +21722,12 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/wavesurfer.js": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.10.1.tgz",
+            "integrity": "sha512-tF1ptFCAi8SAqKbM1e7705zouLC3z4ulXCg15kSP5dQ7VDV30Q3x/xFRcuVIYTT5+jB/PdkhiBRCfsMshZG1Ug==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/web-namespaces": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-reading-time": "^2.0.2",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "wavesurfer.js": "^7.7.11"
     },
     "devDependencies": {
         "@axe-core/playwright": "4.10.2",
@@ -61,6 +62,7 @@
         "@lhci/cli": "0.15.1",
         "@next/eslint-plugin-next": "15.5.0",
         "@playwright/test": "1.55.0",
+        "@storybook/addon-a11y": "9.1.2",
         "@storybook/nextjs": "^9.1.1",
         "@types/node": "24.3.0",
         "@types/react": "19.1.10",

--- a/types/wavesurfer.d.ts
+++ b/types/wavesurfer.d.ts
@@ -1,0 +1,20 @@
+declare module "wavesurfer.js" {
+    export interface WaveSurferOptions {
+        container: HTMLElement;
+        waveColor: string;
+        progressColor: string;
+        cursorWidth: number;
+        url: string;
+    }
+
+    export default class WaveSurfer {
+        static create(options: WaveSurferOptions): WaveSurfer;
+        on(event: string, callback: () => void): void;
+        destroy(): void;
+        getDuration(): number;
+        getCurrentTime(): number;
+        isPlaying(): boolean;
+        playPause(): void;
+        setTime(time: number): void;
+    }
+}


### PR DESCRIPTION
## Summary
- add accessible `AudioPlayer` component with optional waveform
- show audio player states in Storybook and enable a11y addon
- include wavesurfer.js and Storybook a11y dependency
- remove eslint disables and add WaveSurfer types

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7592e27bc83288a9df1397576f8dc