### PR TITLE
Ensure audio player waits for waveform before playback

### DIFF
--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -40,6 +40,8 @@ export default function AudioPlayer({ src, title }: Props) {
 
         ws.on("ready", () => {
             setDuration(ws.getDuration());
+        });
+        ws.on("redrawcomplete", () => {
             setLoading(false);
         });
         ws.on("play", () => {
@@ -65,7 +67,9 @@ export default function AudioPlayer({ src, title }: Props) {
 
         function onLoadedMetadata() {
             setDuration(audioEl.duration);
-            setLoading(false);
+            if (!waveSurferRef.current) {
+                setLoading(false);
+            }
         }
         function onTimeUpdate() {
             setCurrentTime(audioEl.currentTime);


### PR DESCRIPTION
## Summary
- defer audio player readiness until waveform redraw completes
- start playback only after WaveSurfer renders a waveform

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: browserType.launch target closed)*

------
https://chatgpt.com/codex/tasks/task_e_68a78403911c83288a9289fcf22052f8