### PR TITLE
Limit audio loading overlay to waveform

### DIFF
--- a/components/AudioPlayer/AudioPlayer.module.scss
+++ b/components/AudioPlayer/AudioPlayer.module.scss
@@ -55,6 +55,10 @@
     font-variant-numeric: tabular-nums;
 }
 
+.waveformWrapper {
+    position: relative;
+}
+
 .waveform {
     inline-size: 100%;
     block-size: var(--space-3xl);

--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -156,9 +156,11 @@ export default function AudioPlayer({ src, title }: Props) {
                 className={styles.native}
                 aria-hidden="true"
             />
-            <div className={loadingClasses} />
             <p>Listen to this article:</p>
-            <div ref={waveformRef} className={styles.waveform} />
+            <div className={styles.waveformWrapper}>
+                <div ref={waveformRef} className={styles.waveform} />
+                <div className={loadingClasses} />
+            </div>
             <div className={styles.controls}>
                 <Button
                     onClick={togglePlay}


### PR DESCRIPTION
## Summary
- restrict audio player loading overlay to waveform area
- add waveform wrapper for scoped loading effect

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79d75d8a08328bc77ca50d0cf0b2d