### PR TITLE
feat: use semantic font-weight tokens

### DIFF
--- a/components/Button/Button.module.scss
+++ b/components/Button/Button.module.scss
@@ -7,7 +7,7 @@
     cursor: pointer;
     font: inherit;
     font-family: var(--font-header), sans-serif;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     text-decoration: none;
     padding-block: var(--space-s);
     padding-inline: var(--space-m);

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -34,7 +34,7 @@
     text-decoration: none;
     color: var(--colour-text);
     font-size: var(--typography-size-200);
-    font-weight: 400;
+    font-weight: var(--font-weight-regular);
     font-family: var(--font-header), sans-serif;
     transition: color var(--motion-dur-200) var(--motion-ease-standard);
 }

--- a/styles/_tokens.scss
+++ b/styles/_tokens.scss
@@ -98,6 +98,8 @@
         0 4px 8px hsl(0deg 0% 0% / 12%), 0 2px 4px hsl(0deg 0% 0% / 8%);
 
     /* typography */
+    --font-weight-regular: 400;
+    --font-weight-semibold: 600;
     --typography-size-100: clamp(0.875rem, 0.84rem + 0.2vw, 0.95rem);
     --typography-size-200: clamp(1rem, 0.96rem + 0.3vw, 1.1rem);
     --typography-size-300: clamp(1.25rem, 1.15rem + 0.6vw, 1.5rem);

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -14,7 +14,7 @@
             content: counter(step) ".";
             position: absolute;
             inset-inline-start: calc(var(--space-l) * -1);
-            font-weight: 600;
+            font-weight: var(--font-weight-semibold);
         }
     }
 }
@@ -33,7 +33,7 @@
             content: "\2713";
             position: absolute;
             inset-inline-start: calc(var(--space-l) * -1);
-            font-weight: 600;
+            font-weight: var(--font-weight-semibold);
             color: var(--colour-success);
         }
 
@@ -44,7 +44,7 @@
         }
 
         dt {
-            font-weight: 600;
+            font-weight: var(--font-weight-semibold);
             font-family: var(--font-header), sans-serif;
             margin-inline-end: var(--space-s);
         }


### PR DESCRIPTION
## Summary
- add semantic font-weight tokens to design system
- apply font-weight tokens to Button, Header, and mixins

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: accessibility violations in articles and smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d64c525c832893e3901d2bfc907a