### PR TITLE
refactor: centralize flex stacks

### DIFF
--- a/app/articles/[year]/[slug]/page.module.scss
+++ b/app/articles/[year]/[slug]/page.module.scss
@@ -41,9 +41,8 @@
 }
 
 .article :global(figcaption) {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    @include centered-column;
+
     justify-content: center;
     padding: var(--space-s);
 }

--- a/components/AudioPlayer/AudioPlayer.module.scss
+++ b/components/AudioPlayer/AudioPlayer.module.scss
@@ -22,9 +22,9 @@
 
 .player {
     position: relative;
-    display: flex;
-    gap: var(--space-xs);
-    flex-direction: column;
+
+    @include stack(var(--space-xs));
+
     margin-block-start: var(--space-l);
     border: var(--border-width-s) solid var(--colour-border);
     border-radius: var(--radius-m);

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -5,9 +5,9 @@
     border-radius: var(--radius-l);
     padding: var(--space-l);
     box-shadow: var(--shadow-elev-1);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-m);
+
+    @include stack;
+
     color: var(--colour-text);
     will-change: box-shadow, transform, background;
     transition:
@@ -61,8 +61,8 @@
 }
 
 .body {
-    display: flex;
-    flex-direction: column;
+    @include stack(null);
+
     flex-grow: 1;
     font-size: var(--typography-size-200);
 }

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -52,8 +52,8 @@
 }
 
 .logoLockup {
-    display: flex;
-    flex-direction: column;
+    @include stack(null);
+
     font-family: inherit;
 
     span {

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -1,3 +1,5 @@
+@use "mixins" as *;
+
 *,
 *::before,
 *::after {
@@ -30,8 +32,9 @@ body {
         background-color var(--motion-dur-200) var(--motion-ease-standard),
         color var(--motion-dur-200) var(--motion-ease-standard);
     will-change: background-color, color;
-    display: flex;
-    flex-direction: column;
+
+    @include stack(null);
+
     min-block-size: 100vh;
     font-family: var(--font-body), sans-serif;
     line-height: var(--typography-line-normal);
@@ -39,8 +42,8 @@ body {
 
 main {
     flex: 1 0 auto;
-    display: flex;
-    flex-direction: column;
+
+    @include stack(null);
 }
 
 @supports (font-size: clamp(1rem, 1vw, 2rem)) {

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,7 +1,15 @@
-@mixin steps {
+@mixin stack($gap: var(--space-m)) {
     display: flex;
     flex-direction: column;
-    gap: var(--space-m);
+
+    @if $gap != null {
+        gap: $gap;
+    }
+}
+
+@mixin steps {
+    @include stack;
+
     counter-reset: step;
 
     li {
@@ -20,9 +28,8 @@
 }
 
 @mixin checklist {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-m);
+    @include stack;
+
     margin-inline-start: var(--space-2xl);
 
     > div {


### PR DESCRIPTION
## Summary
- add reusable `stack` mixin for flex column layouts
- apply mixins to base and component styles to reduce duplication
- reuse `centered-column` mixin in article figcaptions

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a83e678f6883288f68103ac5a6cc48