### PR TITLE
feat: make table of contents collapsible

### DIFF
--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -11,7 +11,81 @@
 
     :where(h2) {
         font-size: var(--typography-size-200);
-        margin-bottom: var(--space-m);
+        margin: 0;
+    }
+}
+
+.header {
+    @include flex-between(center);
+
+    margin-block-end: var(--space-m);
+}
+
+.toggle {
+    @include inline-center;
+
+    min-block-size: var(--size-tap-min);
+    min-inline-size: var(--size-tap-min);
+    padding: var(--space-xs);
+    background: none;
+    border: none;
+    color: var(--colour-text);
+    cursor: pointer;
+    transition:
+        color var(--motion-dur-200) var(--motion-ease-standard),
+        transform var(--motion-dur-120) var(--motion-ease-emphasized);
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            color: var(--colour-primary);
+            transform: scale(1.1);
+        }
+
+        &:active {
+            transform: scale(0.95);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+        transform: none;
+    }
+}
+
+.icon {
+    inline-size: var(--size-icon-m);
+    block-size: var(--size-icon-m);
+    fill: currentcolor;
+    transition: transform var(--motion-dur-320) var(--motion-ease-emphasized);
+}
+
+.toggle[aria-expanded="false"] .icon {
+    transform: rotate(180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .icon {
+        transition: none;
+    }
+}
+
+.content {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition:
+        grid-template-rows var(--motion-dur-320) var(--motion-ease-standard),
+        opacity var(--motion-dur-200) var(--motion-ease-standard);
+    overflow: hidden;
+}
+
+.collapsed {
+    grid-template-rows: 0fr;
+    opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .content {
+        transition: none;
     }
 }
 

--- a/components/TableOfContents/TableOfContents.tsx
+++ b/components/TableOfContents/TableOfContents.tsx
@@ -1,4 +1,9 @@
-import type { FC } from "react";
+"use client";
+
+import type { FC, SVGProps } from "react";
+import { useState } from "react";
+import clsx from "clsx";
+import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
 import styles from "./TableOfContents.module.scss";
 
 export type TableOfContentsHeading = {
@@ -11,27 +16,67 @@ type Props = {
     headings: TableOfContentsHeading[];
 };
 
+function ChevronIcon(props: SVGProps<SVGSVGElement>) {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+            <path
+                d="M6 15 12 9l6 6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
+
 const TableOfContents: FC<Props> = ({ headings }) => {
+    const [open, setOpen] = useState(true);
+
     if (headings.length === 0) {
         return null;
     }
 
+    const label = open
+        ? "Collapse table of contents"
+        : "Expand table of contents";
+
     return (
         <nav aria-labelledby="toc-heading" className={styles.toc}>
-            <h2 id="toc-heading">Table of contents</h2>
-            <ol className={styles.list}>
-                {headings.map((heading) => (
-                    <li
-                        key={heading.id}
-                        className={styles.item}
-                        data-level={heading.level}
-                    >
-                        <a href={`#${heading.id}`} className={styles.link}>
-                            {heading.text}
-                        </a>
-                    </li>
-                ))}
-            </ol>
+            <div className={styles.header}>
+                <h2 id="toc-heading">Table of contents</h2>
+                <button
+                    type="button"
+                    className={styles.toggle}
+                    aria-expanded={open}
+                    aria-controls="toc-list"
+                    onClick={() => {
+                        setOpen((prev) => !prev);
+                    }}
+                >
+                    <ChevronIcon className={styles.icon} />
+                    <VisuallyHidden>{label}</VisuallyHidden>
+                </button>
+            </div>
+            <div
+                id="toc-list"
+                className={clsx(styles.content, !open && styles.collapsed)}
+            >
+                <ol className={styles.list}>
+                    {headings.map((heading) => (
+                        <li
+                            key={heading.id}
+                            className={styles.item}
+                            data-level={heading.level}
+                        >
+                            <a href={`#${heading.id}`} className={styles.link}>
+                                {heading.text}
+                            </a>
+                        </li>
+                    ))}
+                </ol>
+            </div>
         </nav>
     );
 };


### PR DESCRIPTION
## Summary
- allow table of contents to be collapsed or expanded with a toggle button
- animate table of contents reveal while respecting reduced-motion preferences

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a845b44ecc83288d80af5b38a8c0ac