### PR TITLE
Ensure CV PDF is generated during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "scripts": {
         "dev": "npm run build:tokens:watch & next dev --turbopack",
         "start": "npx serve@latest out",
-        "build": "npm run build:tokens && next build",
+        "build": "npm run build:tokens && npm run build:cv && next build",
         "export": "next export",
         "build:cv": "node ./node_modules/@lapidist/cv-generator/dist/es5/cli.js && mv brett-dorrans-cv.pdf public/",
         "build:sw": "tsc -p tsconfig.sw.json && tsx scripts/build-sw.mts",


### PR DESCRIPTION
## Summary
- generate CV PDF during build so brett-dorrans-cv.pdf is always available

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87baa42ec8328adddf515d4c05fd7