### PR TITLE
fix: position and align burger menu

### DIFF
--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -98,6 +98,8 @@
 .burgerIcon::after {
     content: "";
     position: absolute;
+    inset-inline-start: 0;
+    inset-block-start: 0;
     inline-size: var(--size-icon-m);
     block-size: var(--border-width-m);
     background: currentcolor;

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -36,6 +36,7 @@ export default function Header() {
         placement: "bottom-end",
         middleware: [offset(8)],
         whileElementsMounted: autoUpdate,
+        strategy: "fixed",
     });
     const click = useClick(context);
     const dismiss = useDismiss(context);


### PR DESCRIPTION
## Summary
- ensure floating menu opens relative to trigger
- align burger icon bars for consistent spacing

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test` *(fails: home renders with basic a11y and performance)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d1d93fbc8328a1e48b695ebf42bb