### PR TITLE
feat: add homepage metadata

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Script from "next/script";
 import Approach from "@/components/Approach/Approach";
 import Contact from "@/components/Contact/Contact";
@@ -11,6 +12,28 @@ import TrustedBy from "@/components/TrustedBy/TrustedBy";
 import WhatIBring from "@/components/WhatIBring/WhatIBring";
 import { getAllArticles } from "@/lib/articles";
 import { buildHomePageStructuredData } from "@/lib/structured-data";
+
+const DESCRIPTION =
+    "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.";
+
+export const metadata: Metadata = {
+    description: DESCRIPTION,
+    alternates: { canonical: "/" },
+    openGraph: {
+        title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
+        description: DESCRIPTION,
+        url: "/",
+        type: "website",
+        images: [{ url: "/opengraph-image" }],
+        siteName: "Lapidist",
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
+        description: DESCRIPTION,
+        images: ["/twitter-image"],
+    },
+};
 
 export default async function Page() {
     const allArticles = await getAllArticles();


### PR DESCRIPTION
## Summary
- add description metadata to home page
- define Open Graph and Twitter card for social sharing

## Testing
- `CI=1 npm run format`
- `CI=1 npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers` *(fails: aborted due to environment)*
- `npm test` *(fails: web server exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a97ea5a310832890549d72409084ef