### PR TITLE
fix token build watch

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,7 @@ export default [
                 },
             },
         },
-        files: ["**/*.{ts,tsx,js,jsx}"],
+        files: ["**/*.{ts,tsx,js,jsx,mjs}"],
         languageOptions: {
             parserOptions: {
                 project: ["./tsconfig.json"],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "preqa": "npm run build",
         "qa": "start-server-and-test start http://localhost:3000 lh:ci",
         "build:tokens": "style-dictionary build --config style-dictionary.config.mjs",
-        "build:tokens:watch": "style-dictionary build --config style-dictionary.config.mjs --watch"
+        "build:tokens:watch": "node scripts/build-tokens-watch.mjs"
     },
     "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/scripts/build-tokens-watch.mjs
+++ b/scripts/build-tokens-watch.mjs
@@ -1,0 +1,25 @@
+import { execSync } from "node:child_process";
+import { watch } from "node:fs";
+import path from "node:path";
+
+const TOKENS_DIR = path.join(process.cwd(), "tokens");
+
+function build() {
+    execSync(
+        "npx style-dictionary build --config style-dictionary.config.mjs",
+        { stdio: "inherit" },
+    );
+}
+
+build();
+
+/** @type {NodeJS.Timeout | undefined} */
+let timeout;
+watch(TOKENS_DIR, (event, filename) => {
+    if (!filename || !filename.endsWith(".json")) return;
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => {
+        console.log(`Rebuilding tokens due to changes in ${filename}`);
+        build();
+    }, 100);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "include": [
         "next-env.d.ts",
         ".storybook",
+        "scripts/**/*.mjs",
         "**/*.ts",
         "**/*.tsx",
         ".next/types/**/*.ts"


### PR DESCRIPTION
## Summary
- type token watch script instead of disabling lint rule
- include watch script in TypeScript and ESLint configs

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97df7c998832884b3f99306aecb4a