### PR TITLE
refactor Card component

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -61,7 +61,7 @@ export default async function ArticlesPage() {
                                 href={`/articles/${year}/${slug}`}
                                 className={styles.cardLink}
                             >
-                                <Card title={title} headingLevel="h2">
+                                <Card heading={title} headingLevel={2}>
                                     <p className={styles.summary}>{summary}</p>
                                     <p className={styles.meta}>
                                         {formatDate(date)}

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -54,6 +54,7 @@
     @include flex-between(flex-start, var(--space-s));
 }
 
+.head h2,
 .head h3,
 .head h4 {
     margin: 0;
@@ -72,6 +73,7 @@
         padding: var(--space-m);
     }
 
+    .head h2,
     .head h3,
     .head h4 {
         font-size: var(--typography-size-200);

--- a/components/Card/Card.stories.tsx
+++ b/components/Card/Card.stories.tsx
@@ -5,7 +5,7 @@ const meta = {
     title: "Components/Card",
     component: Card,
     args: {
-        title: "Card title",
+        heading: "Card heading",
         children: "Card content",
     },
 } satisfies Meta<typeof Card>;
@@ -28,17 +28,17 @@ export const LargeHighlighted: Story = {
 };
 
 export const HeadingLevel4: Story = {
-    args: { headingLevel: "h4" },
+    args: { headingLevel: 4 },
 };
 
 export const HeadingLevel4Highlighted: Story = {
-    args: { headingLevel: "h4", highlight: true },
+    args: { headingLevel: 4, highlight: true },
 };
 
 export const LargeHeadingLevel4: Story = {
-    args: { size: "lg", headingLevel: "h4" },
+    args: { size: "lg", headingLevel: 4 },
 };
 
 export const LargeHeadingLevel4Highlighted: Story = {
-    args: { size: "lg", headingLevel: "h4", highlight: true },
+    args: { size: "lg", headingLevel: 4, highlight: true },
 };

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -1,41 +1,55 @@
-import type { ElementType, ReactNode } from "react";
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
+import { forwardRef } from "react";
 import clsx from "clsx";
 import styles from "./Card.module.scss";
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLElement> {
     as?: ElementType;
-    title: string;
+    heading: ReactNode;
     highlight?: boolean;
     children: ReactNode;
-    headingLevel?: "h2" | "h3" | "h4";
+    headingLevel?: 2 | 3 | 4;
     size?: "md" | "lg";
     className?: string;
     icon?: ReactNode;
 }
 
-export default function Card({
-    as: Component = "article",
-    title,
-    highlight,
-    children,
-    headingLevel = "h3",
-    size = "md",
-    className,
-    icon,
-}: Props) {
-    const Heading = headingLevel as ElementType;
-    const classes = clsx(styles.card, className);
-    return (
-        <Component
-            className={classes}
-            data-highlight={highlight || undefined}
-            data-size={size}
-        >
-            <header className={styles.head}>
-                <Heading>{title}</Heading>
-                {icon}
-            </header>
-            <div className={styles.body}>{children}</div>
-        </Component>
-    );
-}
+const Card = forwardRef<HTMLElement, Props>(
+    (
+        {
+            as: Component = "article",
+            heading,
+            highlight,
+            children,
+            headingLevel = 3,
+            size = "md",
+            className,
+            icon,
+            ...rest
+        },
+        ref,
+    ) => {
+        const Heading = `h${String(headingLevel)}` as unknown as ElementType;
+        const classes = clsx(styles.card, className);
+
+        return (
+            <Component
+                ref={ref}
+                className={classes}
+                data-highlight={highlight || undefined}
+                data-size={size}
+                {...rest}
+            >
+                <header className={styles.head}>
+                    <Heading>{heading}</Heading>
+                    {icon}
+                </header>
+                <div className={styles.body}>{children}</div>
+            </Component>
+        );
+    },
+);
+
+Card.displayName = "Card";
+
+export default Card;

--- a/components/Insights/Insights.tsx
+++ b/components/Insights/Insights.tsx
@@ -38,7 +38,7 @@ export default function Insights({ articles }: { articles: Article[] }) {
                             href={`/articles/${year}/${slug}`}
                             className={styles.cardLink}
                         >
-                            <Card title={title}>
+                            <Card heading={title}>
                                 <p className={styles.summary}>{summary}</p>
                                 <p className={styles.meta}>
                                     {formatDate(date)}

--- a/components/Services/Services.tsx
+++ b/components/Services/Services.tsx
@@ -16,7 +16,7 @@ export default function Services() {
         >
             <div className={styles.cards}>
                 <Card
-                    title="Design System Bootstrap"
+                    heading="Design System Bootstrap"
                     icon={<DesignSystemBootstrapIcon className={styles.icon} />}
                 >
                     <p>
@@ -26,7 +26,7 @@ export default function Services() {
                     </p>
                 </Card>
                 <Card
-                    title="System Audit & Roadmap"
+                    heading="System Audit & Roadmap"
                     icon={<SystemAuditRoadmapIcon className={styles.icon} />}
                 >
                     <p>
@@ -35,7 +35,7 @@ export default function Services() {
                     </p>
                 </Card>
                 <Card
-                    title="Hands-on Build"
+                    heading="Hands-on Build"
                     icon={<HandsOnBuildIcon className={styles.icon} />}
                 >
                     <p>
@@ -44,7 +44,7 @@ export default function Services() {
                     </p>
                 </Card>
                 <Card
-                    title="Consulting & Team Uplift"
+                    heading="Consulting & Team Uplift"
                     icon={<ConsultingTeamUpliftIcon className={styles.icon} />}
                 >
                     <p>


### PR DESCRIPTION
## Summary
- refactor Card to accept `heading` content and forward props
- add h2 styling and numeric heading levels
- update Card usages and stories for new API

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9aaa00e108328a0cedffe44f6dd04