### PR TITLE
refactor: consolidate card styles

### DIFF
--- a/app/articles/page.module.scss
+++ b/app/articles/page.module.scss
@@ -12,11 +12,6 @@
     @include card-grid();
 }
 
-.cardLink {
-    text-decoration: none;
-    color: inherit;
-}
-
 .summary {
     color: var(--colour-text-subtle);
     font-size: var(--typography-size-200);

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -56,26 +56,27 @@ export default async function ArticlesPage() {
                             tags,
                             readingTime,
                         }) => (
-                            <Link
+                            <Card
                                 key={`${year}-${slug}`}
+                                as={Link}
                                 href={`/articles/${year}/${slug}`}
-                                className={styles.cardLink}
+                                heading={title}
+                                headingLevel={2}
+                                variant="link"
                             >
-                                <Card heading={title} headingLevel={2}>
-                                    <p className={styles.summary}>{summary}</p>
-                                    <p className={styles.meta}>
-                                        {formatDate(date)}
-                                        {tags.length > 0 || readingTime
-                                            ? " · "
-                                            : ""}
-                                        {tags.join(", ")}
-                                        {tags.length > 0 && readingTime
-                                            ? " · "
-                                            : ""}
-                                        {readingTime}
-                                    </p>
-                                </Card>
-                            </Link>
+                                <p className={styles.summary}>{summary}</p>
+                                <p className={styles.meta}>
+                                    {formatDate(date)}
+                                    {tags.length > 0 || readingTime
+                                        ? " · "
+                                        : ""}
+                                    {tags.join(", ")}
+                                    {tags.length > 0 && readingTime
+                                        ? " · "
+                                        : ""}
+                                    {readingTime}
+                                </p>
+                            </Card>
                         ),
                     )}
                 </div>

--- a/components/Approach/Approach.module.scss
+++ b/components/Approach/Approach.module.scss
@@ -8,43 +8,6 @@
     margin: 0;
     padding: 0;
     margin-block: var(--space-l);
-
-    li {
-        display: flex;
-        flex-direction: column;
-        counter-increment: step;
-        position: relative;
-        padding: var(--space-m);
-        padding-inline-start: calc(var(--size-icon-l) + var(--space-2xl));
-        border: var(--border-width-s) solid var(--colour-border);
-        border-radius: var(--radius-m);
-        background: var(--surface-level-2);
-        box-shadow: var(--shadow-elev-1);
-
-        &::before {
-            content: counter(step);
-            position: absolute;
-            inset-inline-start: var(--space-m);
-            inline-size: var(--size-icon-l);
-            block-size: var(--size-icon-l);
-            border-radius: var(--radius-m);
-            background: var(--colour-primary);
-            color: var(--colour-on-primary);
-            font-weight: var(--font-weight-semibold);
-
-            @include inline-center;
-        }
-
-        strong {
-            font-family: var(--font-header), sans-serif;
-            font-weight: var(--font-weight-semibold);
-            line-height: var(--typography-line-tight);
-        }
-
-        p {
-            margin: 0;
-        }
-    }
 }
 
 .summary {

--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -1,3 +1,4 @@
+import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import styles from "./Approach.module.scss";
 
@@ -36,10 +37,10 @@ export default function Approach({ steps = DEFAULT_STEPS }: Props) {
         <Section id="approach" heading="My approach">
             <ol className={styles.steps}>
                 {steps.map(({ title, description }) => (
-                    <li key={title}>
+                    <Card as="li" key={title} variant="step">
                         <strong>{title}</strong>
                         <p>{description}</p>
-                    </li>
+                    </Card>
                 ))}
             </ol>
             <details>

--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -69,6 +69,61 @@
     font-size: var(--typography-size-200);
 }
 
+.card[data-variant="link"] {
+    color: inherit;
+    text-decoration: none;
+}
+
+.card[data-variant="testimonial"] {
+    @include centered-column;
+
+    gap: var(--space-m);
+
+    blockquote {
+        margin: 0;
+        font-size: var(--typography-size-200);
+    }
+
+    figcaption {
+        font-size: var(--typography-size-100);
+        color: var(--colour-text);
+    }
+}
+
+.card[data-variant="step"] {
+    padding: var(--space-m);
+    padding-inline-start: calc(var(--size-icon-l) + var(--space-2xl));
+    border-radius: var(--radius-m);
+    background: var(--surface-level-2);
+    position: relative;
+    counter-increment: step;
+    gap: 0;
+
+    &::before {
+        content: counter(step);
+        position: absolute;
+        inset-inline-start: var(--space-m);
+        inline-size: var(--size-icon-l);
+        block-size: var(--size-icon-l);
+        border-radius: var(--radius-m);
+        background: var(--colour-primary);
+        color: var(--colour-on-primary);
+        font-weight: var(--font-weight-semibold);
+
+        @include inline-center;
+    }
+
+    strong {
+        font-family: var(--font-header), sans-serif;
+        font-weight: var(--font-weight-semibold);
+        line-height: var(--typography-line-tight);
+    }
+
+    p {
+        margin: 0;
+    }
+}
+
 @container section (max-width: 40rem) {
     .card {
         padding: var(--space-m);

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -5,13 +5,15 @@ import styles from "./Card.module.scss";
 
 interface Props extends HTMLAttributes<HTMLElement> {
     as?: ElementType;
-    heading: ReactNode;
+    heading?: ReactNode;
     highlight?: boolean;
     children: ReactNode;
     headingLevel?: 2 | 3 | 4;
     size?: "md" | "lg";
     className?: string;
     icon?: ReactNode;
+    variant?: "testimonial" | "link" | "step";
+    href?: string;
 }
 
 const Card = forwardRef<HTMLElement, Props>(
@@ -25,6 +27,7 @@ const Card = forwardRef<HTMLElement, Props>(
             size = "md",
             className,
             icon,
+            variant,
             ...rest
         },
         ref,
@@ -32,18 +35,36 @@ const Card = forwardRef<HTMLElement, Props>(
         const Heading = `h${String(headingLevel)}` as unknown as ElementType;
         const classes = clsx(styles.card, className);
 
+        if (variant === "testimonial" || variant === "step") {
+            return (
+                <Component
+                    ref={ref}
+                    className={classes}
+                    data-highlight={highlight || undefined}
+                    data-size={size}
+                    data-variant={variant}
+                    {...rest}
+                >
+                    {children}
+                </Component>
+            );
+        }
+
         return (
             <Component
                 ref={ref}
                 className={classes}
                 data-highlight={highlight || undefined}
                 data-size={size}
+                data-variant={variant}
                 {...rest}
             >
-                <header className={styles.head}>
-                    <Heading>{heading}</Heading>
-                    {icon}
-                </header>
+                {(heading || icon) && (
+                    <header className={styles.head}>
+                        {heading && <Heading>{heading}</Heading>}
+                        {icon}
+                    </header>
+                )}
                 <div className={styles.body}>{children}</div>
             </Component>
         );

--- a/components/Insights/Insights.module.scss
+++ b/components/Insights/Insights.module.scss
@@ -8,11 +8,6 @@
     @include card-grid();
 }
 
-.cardLink {
-    text-decoration: none;
-    color: inherit;
-}
-
 .cta {
     @include cta-group;
 }

--- a/components/Insights/Insights.tsx
+++ b/components/Insights/Insights.tsx
@@ -33,26 +33,22 @@ export default function Insights({ articles }: { articles: Article[] }) {
                         tags,
                         readingTime,
                     }) => (
-                        <Link
+                        <Card
                             key={`${year}-${slug}`}
+                            as={Link}
                             href={`/articles/${year}/${slug}`}
-                            className={styles.cardLink}
+                            heading={title}
+                            variant="link"
                         >
-                            <Card heading={title}>
-                                <p className={styles.summary}>{summary}</p>
-                                <p className={styles.meta}>
-                                    {formatDate(date)}
-                                    {tags.length > 0 || readingTime
-                                        ? " · "
-                                        : ""}
-                                    {tags.join(", ")}
-                                    {tags.length > 0 && readingTime
-                                        ? " · "
-                                        : ""}
-                                    {readingTime}
-                                </p>
-                            </Card>
-                        </Link>
+                            <p className={styles.summary}>{summary}</p>
+                            <p className={styles.meta}>
+                                {formatDate(date)}
+                                {tags.length > 0 || readingTime ? " · " : ""}
+                                {tags.join(", ")}
+                                {tags.length > 0 && readingTime ? " · " : ""}
+                                {readingTime}
+                            </p>
+                        </Card>
                     ),
                 )}
             </div>

--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -3,21 +3,18 @@
 .toc {
     max-inline-size: 40ch;
     padding: var(--space-m);
-    border: var(--border-width-s) solid var(--colour-border);
-    border-radius: var(--radius-m);
-    box-shadow: var(--shadow-elev-1);
-    background: var(--surface-level-1);
     margin-block: var(--space-l);
     margin-block-end: var(--space-3xl);
+
+    header {
+        align-items: center;
+        gap: 0;
+    }
 
     :where(h2) {
         font-size: var(--typography-size-200);
         margin: 0;
     }
-}
-
-.header {
-    @include flex-between(center);
 }
 
 .toggle {

--- a/components/TableOfContents/TableOfContents.tsx
+++ b/components/TableOfContents/TableOfContents.tsx
@@ -3,6 +3,7 @@
 import type { FC, SVGProps } from "react";
 import { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
+import Card from "@/components/Card/Card";
 import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
 import styles from "./TableOfContents.module.scss";
 
@@ -51,9 +52,12 @@ const TableOfContents: FC<Props> = ({ headings }) => {
         : "Expand table of contents";
 
     return (
-        <nav aria-labelledby="toc-heading" className={styles.toc}>
-            <div className={styles.header}>
-                <h2 id="toc-heading">Table of contents</h2>
+        <Card
+            as="nav"
+            aria-labelledby="toc-heading"
+            className={styles.toc}
+            heading={<span id="toc-heading">Table of contents</span>}
+            icon={
                 <button
                     type="button"
                     className={styles.toggle}
@@ -66,7 +70,9 @@ const TableOfContents: FC<Props> = ({ headings }) => {
                     <ChevronIcon className={styles.icon} />
                     <VisuallyHidden>{label}</VisuallyHidden>
                 </button>
-            </div>
+            }
+            headingLevel={2}
+        >
             <div
                 id="toc-list"
                 ref={contentRef}
@@ -87,7 +93,7 @@ const TableOfContents: FC<Props> = ({ headings }) => {
                     ))}
                 </ol>
             </div>
-        </nav>
+        </Card>
     );
 };
 

--- a/components/Testimonials/Testimonials.module.scss
+++ b/components/Testimonials/Testimonials.module.scss
@@ -8,27 +8,6 @@
     @include card-grid();
 }
 
-.card {
-    background: var(--surface-level-1);
-    padding: var(--space-l);
-    border-radius: var(--radius-l);
-    border: var(--border-width-s) solid var(--colour-border);
-
-    @include centered-column;
-
-    gap: var(--space-m);
-}
-
-.card blockquote {
-    margin: 0;
-    font-size: var(--typography-size-200);
-}
-
-.card figcaption {
-    font-size: var(--typography-size-100);
-    color: var(--colour-text);
-}
-
 @container (min-width:50rem) {
     .cards {
         grid-template-columns: repeat(2, 1fr);

--- a/components/Testimonials/Testimonials.tsx
+++ b/components/Testimonials/Testimonials.tsx
@@ -1,3 +1,4 @@
+import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import styles from "./Testimonials.module.scss";
 
@@ -9,7 +10,7 @@ export default function Testimonials() {
             className={styles.testimonials}
         >
             <div className={styles.cards}>
-                <figure className={styles.card}>
+                <Card as="figure" variant="testimonial">
                     <blockquote>
                         “Brett is as rock solid as they get. He&apos;s a
                         standout professional whose multidimensional skills and
@@ -20,8 +21,8 @@ export default function Testimonials() {
                         <br />
                         Engineering Lead at Wise
                     </figcaption>
-                </figure>
-                <figure className={styles.card}>
+                </Card>
+                <Card as="figure" variant="testimonial">
                     <blockquote>
                         “Brett&apos;s contributions to the design systems team
                         have played a crucial role in planning and creating
@@ -32,7 +33,7 @@ export default function Testimonials() {
                         <br />
                         Senior Engineer at LendInvest
                     </figcaption>
-                </figure>
+                </Card>
             </div>
         </Section>
     );


### PR DESCRIPTION
## Summary
- add link, testimonial, and step variants to Card to centralize shared styling
- use Card variants in Articles, Insights, Testimonials, Approach, and Table of Contents to eliminate bespoke `.card` rules

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c200a1148328826176ab1dafd7e2