### PR TITLE
feat: centralize size and variant enums

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -6,6 +6,7 @@ import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
 import { getAllArticles } from "@/lib/articles";
 import { formatDate } from "@/lib/date";
+import { Variant } from "@/lib/enums";
 import styles from "./page.module.scss";
 
 export const metadata: Metadata = {
@@ -62,7 +63,7 @@ export default async function ArticlesPage() {
                                 href={`/articles/${year}/${slug}`}
                                 heading={title}
                                 headingLevel={2}
-                                variant="link"
+                                variant={Variant.Link}
                             >
                                 <p className={styles.summary}>{summary}</p>
                                 <p className={styles.meta}>

--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -1,5 +1,6 @@
 import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
+import { Variant } from "@/lib/enums";
 import styles from "./Approach.module.scss";
 
 export interface Step {
@@ -37,7 +38,7 @@ export default function Approach({ steps = DEFAULT_STEPS }: Props) {
         <Section id="approach" heading="My approach">
             <ol className={styles.steps}>
                 {steps.map(({ title, description }) => (
-                    <Card as="li" key={title} variant="step">
+                    <Card as="li" key={title} variant={Variant.Step}>
                         <strong>{title}</strong>
                         <p>{description}</p>
                     </Card>

--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -12,6 +12,7 @@ import clsx from "clsx";
 import WaveSurfer from "wavesurfer.js";
 import Button from "@/components/Button/Button";
 import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
+import { Size, Variant } from "@/lib/enums";
 import styles from "./AudioPlayer.module.scss";
 
 type Props = {
@@ -183,9 +184,9 @@ export default function AudioPlayer({ src, title }: Props) {
                     onClick={togglePlay}
                     aria-pressed={isPlaying}
                     className={styles.play}
-                    variant="secondary"
+                    variant={Variant.Secondary}
                     disabled={loading}
-                    size="sm"
+                    size={Size.Sm}
                 >
                     {isPlaying ? (
                         <PauseIcon className={styles.icon} />

--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { Size, Variant } from "@/lib/enums";
 import Button from "./Button";
 
 const meta = {
@@ -16,15 +17,15 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Secondary: Story = {
-    args: { variant: "secondary" },
+    args: { variant: Variant.Secondary },
 };
 
 export const Large: Story = {
-    args: { size: "lg" },
+    args: { size: Size.Lg },
 };
 
 export const SecondaryLarge: Story = {
-    args: { variant: "secondary", size: "lg" },
+    args: { variant: Variant.Secondary, size: Size.Lg },
 };
 
 export const AsLink: Story = {

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -6,11 +6,12 @@ import type {
     Ref,
 } from "react";
 import clsx from "clsx";
+import { Size, Variant } from "@/lib/enums";
 import styles from "./Button.module.scss";
 
 type BaseProps = {
-    variant?: "primary" | "secondary";
-    size?: "sm" | "md" | "lg";
+    variant?: Variant.Primary | Variant.Secondary;
+    size?: Size;
     className?: string;
     children: ReactNode;
 };
@@ -27,8 +28,8 @@ type Props = ButtonProps | AnchorProps;
 const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
     (
         {
-            variant = "primary",
-            size = "md",
+            variant = Variant.Primary,
+            size = Size.Md,
             className,
             children,
             href,

--- a/components/Card/Card.stories.tsx
+++ b/components/Card/Card.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { Size } from "@/lib/enums";
 import Card from "./Card";
 
 const meta = {
@@ -20,11 +21,11 @@ export const Highlighted: Story = {
 };
 
 export const Large: Story = {
-    args: { size: "lg" },
+    args: { size: Size.Lg },
 };
 
 export const LargeHighlighted: Story = {
-    args: { size: "lg", highlight: true },
+    args: { size: Size.Lg, highlight: true },
 };
 
 export const HeadingLevel4: Story = {
@@ -36,9 +37,9 @@ export const HeadingLevel4Highlighted: Story = {
 };
 
 export const LargeHeadingLevel4: Story = {
-    args: { size: "lg", headingLevel: 4 },
+    args: { size: Size.Lg, headingLevel: 4 },
 };
 
 export const LargeHeadingLevel4Highlighted: Story = {
-    args: { size: "lg", headingLevel: 4, highlight: true },
+    args: { size: Size.Lg, headingLevel: 4, highlight: true },
 };

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -1,6 +1,7 @@
 import type { ElementType, HTMLAttributes, ReactNode } from "react";
 import { forwardRef } from "react";
 import clsx from "clsx";
+import { Size, Variant } from "@/lib/enums";
 import styles from "./Card.module.scss";
 
 interface Props extends HTMLAttributes<HTMLElement> {
@@ -9,10 +10,10 @@ interface Props extends HTMLAttributes<HTMLElement> {
     highlight?: boolean;
     children: ReactNode;
     headingLevel?: 2 | 3 | 4;
-    size?: "md" | "lg";
+    size?: Size.Md | Size.Lg;
     className?: string;
     icon?: ReactNode;
-    variant?: "testimonial" | "link" | "step";
+    variant?: Variant.Testimonial | Variant.Link | Variant.Step;
     href?: string;
 }
 
@@ -24,7 +25,7 @@ const Card = forwardRef<HTMLElement, Props>(
             highlight,
             children,
             headingLevel = 3,
-            size = "md",
+            size = Size.Md,
             className,
             icon,
             variant,
@@ -35,7 +36,7 @@ const Card = forwardRef<HTMLElement, Props>(
         const Heading = `h${String(headingLevel)}` as unknown as ElementType;
         const classes = clsx(styles.card, className);
 
-        if (variant === "testimonial" || variant === "step") {
+        if (variant === Variant.Testimonial || variant === Variant.Step) {
             return (
                 <Component
                     ref={ref}

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/Button/Button";
 import Section from "@/components/Section/Section";
+import { Variant } from "@/lib/enums";
 import styles from "./Contact.module.scss";
 
 export default function Contact() {
@@ -13,13 +14,16 @@ export default function Contact() {
                 <Button href="mailto:hello@lapidist.net">Get in touch</Button>
                 <Button
                     href="https://cal.com/brett-dorrans-l2qjwo"
-                    variant="secondary"
+                    variant={Variant.Secondary}
                     target="_blank"
                     rel="noopener noreferrer"
                 >
                     Book a call
                 </Button>
-                <Button href="/brett-dorrans-cv.pdf" variant="secondary">
+                <Button
+                    href="/brett-dorrans-cv.pdf"
+                    variant={Variant.Secondary}
+                >
                     Download CV
                 </Button>
             </div>

--- a/components/Container/Container.module.scss
+++ b/components/Container/Container.module.scss
@@ -5,14 +5,14 @@
     container-type: inline-size;
 }
 
-.container[data-size="s"] {
+.container[data-size="sm"] {
     max-width: var(--layout-max-w-s);
 }
 
-.container[data-size="m"] {
+.container[data-size="md"] {
     max-width: var(--layout-max-w-m);
 }
 
-.container[data-size="l"] {
+.container[data-size="lg"] {
     max-width: var(--layout-max-w-l);
 }

--- a/components/Container/Container.stories.tsx
+++ b/components/Container/Container.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { Size } from "@/lib/enums";
 import Container from "./Container";
 
 const meta = {
@@ -15,11 +16,11 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Small: Story = {
-    args: { size: "s" },
+    args: { size: Size.Sm },
 };
 
 export const Large: Story = {
-    args: { size: "l" },
+    args: { size: Size.Lg },
 };
 
 export const Article: Story = {
@@ -31,9 +32,9 @@ export const Page: Story = {
 };
 
 export const SmallPage: Story = {
-    args: { size: "s", cq: "page" },
+    args: { size: Size.Sm, cq: "page" },
 };
 
 export const LargePage: Story = {
-    args: { size: "l", cq: "page" },
+    args: { size: Size.Lg, cq: "page" },
 };

--- a/components/Container/Container.tsx
+++ b/components/Container/Container.tsx
@@ -1,10 +1,11 @@
 import type { ElementType, ReactNode } from "react";
 import clsx from "clsx";
+import { Size } from "@/lib/enums";
 import styles from "./Container.module.scss";
 
 interface Props {
     as?: ElementType;
-    size?: "s" | "m" | "l";
+    size?: Size;
     cq?: "page" | "section";
     className?: string;
     children: ReactNode;
@@ -12,7 +13,7 @@ interface Props {
 
 export default function Container({
     as: Component = "div",
-    size = "m",
+    size = Size.Md,
     cq = "section",
     className,
     children,

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/Button/Button";
 import Section from "@/components/Section/Section";
+import { Size, Variant } from "@/lib/enums";
 import styles from "./Hero.module.scss";
 
 export default function Hero() {
@@ -14,7 +15,7 @@ export default function Hero() {
         <Section
             className={styles.hero}
             labelledBy="hero-heading"
-            containerSize="l"
+            containerSize={Size.Lg}
         >
             <div className={styles.availability}>
                 <p>
@@ -67,7 +68,7 @@ export default function Hero() {
             </div>
             <div className={styles.ctaGroup}>
                 <div className={styles.cta}>
-                    <Button href="#contact" size="lg">
+                    <Button href="#contact" size={Size.Lg}>
                         Discuss your frontend roadmap
                     </Button>
                     <p className={styles.note}>Let&apos;s connect.</p>
@@ -75,8 +76,8 @@ export default function Hero() {
                 <div className={styles.cta}>
                     <Button
                         href="/brett-dorrans-cv.pdf"
-                        size="lg"
-                        variant="secondary"
+                        size={Size.Lg}
+                        variant={Variant.Secondary}
                     >
                         Download capabilities deck
                     </Button>

--- a/components/Insights/Insights.tsx
+++ b/components/Insights/Insights.tsx
@@ -3,6 +3,7 @@ import Button from "@/components/Button/Button";
 import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import { formatDate } from "@/lib/date";
+import { Variant } from "@/lib/enums";
 import styles from "./Insights.module.scss";
 
 type Article = {
@@ -38,7 +39,7 @@ export default function Insights({ articles }: { articles: Article[] }) {
                             as={Link}
                             href={`/articles/${year}/${slug}`}
                             heading={title}
-                            variant="link"
+                            variant={Variant.Link}
                         >
                             <p className={styles.summary}>{summary}</p>
                             <p className={styles.meta}>
@@ -53,7 +54,7 @@ export default function Insights({ articles }: { articles: Article[] }) {
                 )}
             </div>
             <div className={styles.cta}>
-                <Button href="/articles" variant="secondary">
+                <Button href="/articles" variant={Variant.Secondary}>
                     View all articles
                 </Button>
             </div>

--- a/components/Section/Section.stories.tsx
+++ b/components/Section/Section.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { Size } from "@/lib/enums";
 import Section from "./Section";
 
 const meta = {
@@ -16,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const SmallHeadingLevel1: Story = {
-    args: { containerSize: "s", headingLevel: 1 },
+    args: { containerSize: Size.Sm, headingLevel: 1 },
 };
 
 export const HeadingLevel1: Story = {
@@ -24,15 +25,15 @@ export const HeadingLevel1: Story = {
 };
 
 export const LargeHeadingLevel1: Story = {
-    args: { containerSize: "l", headingLevel: 1 },
+    args: { containerSize: Size.Lg, headingLevel: 1 },
 };
 
 export const SmallHeadingLevel2: Story = {
-    args: { containerSize: "s", headingLevel: 2 },
+    args: { containerSize: Size.Sm, headingLevel: 2 },
 };
 
 export const LargeHeadingLevel2: Story = {
-    args: { containerSize: "l", headingLevel: 2 },
+    args: { containerSize: Size.Lg, headingLevel: 2 },
 };
 
 export const HeadingLevel3: Story = {
@@ -40,11 +41,11 @@ export const HeadingLevel3: Story = {
 };
 
 export const SmallHeadingLevel3: Story = {
-    args: { containerSize: "s", headingLevel: 3 },
+    args: { containerSize: Size.Sm, headingLevel: 3 },
 };
 
 export const LargeHeadingLevel3: Story = {
-    args: { containerSize: "l", headingLevel: 3 },
+    args: { containerSize: Size.Lg, headingLevel: 3 },
 };
 
 export const HeadingLevel4: Story = {
@@ -52,11 +53,11 @@ export const HeadingLevel4: Story = {
 };
 
 export const SmallHeadingLevel4: Story = {
-    args: { containerSize: "s", headingLevel: 4 },
+    args: { containerSize: Size.Sm, headingLevel: 4 },
 };
 
 export const LargeHeadingLevel4: Story = {
-    args: { containerSize: "l", headingLevel: 4 },
+    args: { containerSize: Size.Lg, headingLevel: 4 },
 };
 
 export const HeadingLevel5: Story = {
@@ -64,11 +65,11 @@ export const HeadingLevel5: Story = {
 };
 
 export const SmallHeadingLevel5: Story = {
-    args: { containerSize: "s", headingLevel: 5 },
+    args: { containerSize: Size.Sm, headingLevel: 5 },
 };
 
 export const LargeHeadingLevel5: Story = {
-    args: { containerSize: "l", headingLevel: 5 },
+    args: { containerSize: Size.Lg, headingLevel: 5 },
 };
 
 export const HeadingLevel6: Story = {
@@ -76,11 +77,11 @@ export const HeadingLevel6: Story = {
 };
 
 export const SmallHeadingLevel6: Story = {
-    args: { containerSize: "s", headingLevel: 6 },
+    args: { containerSize: Size.Sm, headingLevel: 6 },
 };
 
 export const LargeHeadingLevel6: Story = {
-    args: { containerSize: "l", headingLevel: 6 },
+    args: { containerSize: Size.Lg, headingLevel: 6 },
 };
 
 export const WithoutHeading: Story = {

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ElementType, ReactNode } from "react";
 import Container from "@/components/Container/Container";
+import { Size } from "@/lib/enums";
 
 interface Props {
     id?: string;
@@ -8,7 +9,7 @@ interface Props {
     headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
     headingClassName?: string;
     className?: string;
-    containerSize?: "s" | "m" | "l";
+    containerSize?: Size;
     style?: CSSProperties;
     /**
      * Enables `content-visibility: auto` for this section.

--- a/components/Testimonials/Testimonials.tsx
+++ b/components/Testimonials/Testimonials.tsx
@@ -1,5 +1,6 @@
 import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
+import { Variant } from "@/lib/enums";
 import styles from "./Testimonials.module.scss";
 
 export default function Testimonials() {
@@ -10,7 +11,7 @@ export default function Testimonials() {
             className={styles.testimonials}
         >
             <div className={styles.cards}>
-                <Card as="figure" variant="testimonial">
+                <Card as="figure" variant={Variant.Testimonial}>
                     <blockquote>
                         “Brett is as rock solid as they get. He&apos;s a
                         standout professional whose multidimensional skills and
@@ -22,7 +23,7 @@ export default function Testimonials() {
                         Engineering Lead at Wise
                     </figcaption>
                 </Card>
-                <Card as="figure" variant="testimonial">
+                <Card as="figure" variant={Variant.Testimonial}>
                     <blockquote>
                         “Brett&apos;s contributions to the design systems team
                         have played a crucial role in planning and creating

--- a/lib/enums.ts
+++ b/lib/enums.ts
@@ -1,0 +1,13 @@
+export enum Size {
+    Sm = "sm",
+    Md = "md",
+    Lg = "lg",
+}
+
+export enum Variant {
+    Primary = "primary",
+    Secondary = "secondary",
+    Link = "link",
+    Testimonial = "testimonial",
+    Step = "step",
+}


### PR DESCRIPTION
## Summary
- add shared `Size` and `Variant` enums
- use enums in button, card, container and related components
- normalize container size tokens to `sm`/`md`/`lg`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1a1ca5e083289e0342d137f2b7d0