### PR TITLE
refactor: use Heading component for headings

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Contact from "@/components/Contact/Contact";
 import Footer from "@/components/Footer/Footer";
+import Heading from "@/components/Heading/Heading";
 import Section from "@/components/Section/Section";
 import styles from "./page.module.scss";
 
@@ -58,7 +59,7 @@ export default function AboutPage() {
                         frontend platforms that scale with the business and
                         protect against the hidden costs of technical debt.
                     </p>
-                    <h2>Career highlights</h2>
+                    <Heading level={2}>Career highlights</Heading>
                     <ul>
                         <li>
                             15+ years building and architecting frontends that
@@ -82,7 +83,7 @@ export default function AboutPage() {
                             guiding a team, embedding practices that last.
                         </li>
                     </ul>
-                    <h2>Engineering philosophy</h2>
+                    <Heading level={2}>Engineering philosophy</Heading>
                     <p>
                         In October 2021, at 34, I suffered a cerebellar stroke.
                         Recovery forced me to slow down, rethink, and rebuild -

--- a/app/accessibility-statement/page.tsx
+++ b/app/accessibility-statement/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Container from "@/components/Container/Container";
 import Footer from "@/components/Footer/Footer";
+import Heading from "@/components/Heading/Heading";
 
 export const metadata: Metadata = {
     title: "Accessibility Statement",
@@ -13,25 +14,25 @@ export default function AccessibilityStatementPage() {
     return (
         <>
             <Container as="section">
-                <h1>Accessibility Statement</h1>
+                <Heading level={1}>Accessibility Statement</Heading>
                 <p>
                     I strive to make this website accessible to everyone. If you
                     encounter any accessibility barriers or have suggestions,
                     please get in touch so I can improve the experience.
                 </p>
-                <h2>Standards</h2>
+                <Heading level={2}>Standards</Heading>
                 <p>
                     This site aims to conform to the Web Content Accessibility
                     Guidelines (WCAG) 2.1 Level AA. Pages are regularly reviewed
                     to maintain compliance as content evolves.
                 </p>
-                <h2>High Contrast</h2>
+                <Heading level={2}>High Contrast</Heading>
                 <p>
                     Design and layout are checked with high-contrast modes to
                     ensure text remains legible and interactive elements are
                     clearly distinguishable.
                 </p>
-                <h2>Images</h2>
+                <Heading level={2}>Images</Heading>
                 <p>
                     All meaningful images include descriptive alternative text.
                     Decorative images are either hidden from assistive

--- a/app/ai-ethics-statement/page.tsx
+++ b/app/ai-ethics-statement/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Container from "@/components/Container/Container";
 import Footer from "@/components/Footer/Footer";
+import Heading from "@/components/Heading/Heading";
 
 export const metadata: Metadata = {
     title: "AI Ethics Statement",
@@ -13,7 +14,7 @@ export default function AIEthicsStatementPage() {
     return (
         <>
             <Container as="section">
-                <h1>AI Ethics Statement</h1>
+                <Heading level={1}>AI Ethics Statement</Heading>
                 <p>
                     I use artificial intelligence to edit articles and generate
                     code throughout this site. The following principles guide

--- a/app/dialog-test/page.tsx
+++ b/app/dialog-test/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Dialog from "@/components/Dialog/Dialog";
+import Heading from "@/components/Heading/Heading";
 import { useDisclosure } from "@/components/hooks/useDisclosure";
 
 export default function Page() {
@@ -11,7 +12,9 @@ export default function Page() {
                 Open dialog
             </button>
             <Dialog open={isOpen} onClose={close} aria-labelledby="test-title">
-                <h2 id="test-title">Test dialog</h2>
+                <Heading level={2} id="test-title">
+                    Test dialog
+                </Heading>
                 <p>Content</p>
                 <button onClick={close} data-testid="close">
                     Close

--- a/components/AudioPlayer/AudioPlayer.tsx
+++ b/components/AudioPlayer/AudioPlayer.tsx
@@ -11,6 +11,7 @@ import {
 import clsx from "clsx";
 import WaveSurfer from "wavesurfer.js";
 import Button from "@/components/Button/Button";
+import Heading from "@/components/Heading/Heading";
 import VisuallyHidden from "@/components/VisuallyHidden/VisuallyHidden";
 import { Size, Variant } from "@/packages/types";
 import styles from "./AudioPlayer.module.scss";
@@ -171,9 +172,9 @@ export default function AudioPlayer({ src, title }: Props) {
                 aria-hidden="true"
             />
             {title && (
-                <h2 id={titleId} className={styles.title}>
+                <Heading level={2} id={titleId} className={styles.title}>
                     {title}
-                </h2>
+                </Heading>
             )}
             <div className={styles.waveformWrapper}>
                 <div ref={waveformRef} className={styles.waveform} />

--- a/components/Dialog/Dialog.stories.tsx
+++ b/components/Dialog/Dialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import Heading from "@/components/Heading/Heading";
 import { useDisclosure } from "../hooks/useDisclosure";
 import Dialog from "./Dialog";
 
@@ -23,7 +24,9 @@ export const Playground: Story = {
                     onClose={close}
                     aria-labelledby="dialog-title"
                 >
-                    <h2 id="dialog-title">Example dialog</h2>
+                    <Heading level={2} id="dialog-title">
+                        Example dialog
+                    </Heading>
                     <p>Content</p>
                     <button onClick={close} data-testid="close">
                         Close

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import Button from "@/components/Button/Button";
+import Heading from "@/components/Heading/Heading";
 import Section from "@/components/Section/Section";
 import { Size, Variant } from "@/packages/types";
 import styles from "./Hero.module.scss";
@@ -25,7 +26,11 @@ export default function Hero() {
             </div>
 
             <div className={styles.ctaGroup}>
-                <h1 id="hero-heading" className={styles.heroTitle}>
+                <Heading
+                    level={1}
+                    id="hero-heading"
+                    className={styles.heroTitle}
+                >
                     Lead Frontend Engineer. Crafting{" "}
                     <span className={styles.underline}>
                         resilient
@@ -60,7 +65,7 @@ export default function Hero() {
                         </svg>
                     </span>{" "}
                     design systems.
-                </h1>
+                </Heading>
                 <p className={styles.heroIntro}>
                     I build design systems and frontend platforms that cut
                     rework, lift accessibility, and accelerate delivery.

--- a/components/TokensCatalogue/TokensCatalogue.tsx
+++ b/components/TokensCatalogue/TokensCatalogue.tsx
@@ -1,3 +1,4 @@
+import Heading from "@/components/Heading/Heading";
 import baseTokens from "@/tokens/base.json";
 import lightTokens from "@/tokens/light.json";
 import styles from "./TokensCatalogue.module.scss";
@@ -40,7 +41,7 @@ export default function TokensCatalogue() {
     return (
         <div className={styles.wrapper}>
             <section>
-                <h2>Colours</h2>
+                <Heading level={2}>Colours</Heading>
                 <ul className={styles.list}>
                     {colours.map((t) => (
                         <li key={t.var} className={styles.item}>
@@ -55,7 +56,7 @@ export default function TokensCatalogue() {
                 </ul>
             </section>
             <section>
-                <h2>Icon sizes</h2>
+                <Heading level={2}>Icon sizes</Heading>
                 <ul className={styles.list}>
                     {icons.map((t) => (
                         <li key={t.var} className={styles.item}>


### PR DESCRIPTION
## Summary
- use shared Heading component in Hero, TokensCatalogue, AudioPlayer, and page headings
- replace direct h1/h2 tags in dialog stories and test pages with Heading

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aafe42a76483289e6eac1b3f41364e