### PR TITLE
refactor: encapsulate heading typography

### DIFF
--- a/components/Heading/Heading.module.scss
+++ b/components/Heading/Heading.module.scss
@@ -2,6 +2,9 @@
     font-family: var(--font-header), sans-serif;
     font-weight: var(--font-weight-semibold);
     line-height: var(--typography-line-tight);
+    margin-block: 0;
+    margin-block-end: var(--space-xs);
+    max-inline-size: var(--typography-measure);
 }
 
 .heading[data-level="1"] {
@@ -26,4 +29,17 @@
 
 .heading[data-level="6"] {
     font-size: var(--typography-size-200);
+}
+
+.heading + :where(.heading, p, ul, ol, dl, blockquote) {
+    margin-block-start: var(--space-l);
+}
+
+:where(
+        .heading[data-level="1"],
+        .heading[data-level="2"],
+        .heading[data-level="3"]
+    )
+    + p {
+    margin-block-start: var(--space-l);
 }

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -1,10 +1,3 @@
-:where(h1, h2, h3, h4, h5, h6) {
-    margin-block: 0;
-    margin-block-end: var(--space-xs);
-    line-height: var(--typography-line-tight);
-    max-inline-size: var(--typography-measure);
-}
-
 :where(p, ul, ol, dl, blockquote) {
     margin-block: 0;
     line-height: var(--typography-line-wide);
@@ -12,11 +5,6 @@
     overflow-wrap: anywhere;
 }
 
-:where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote)
-    + :where(h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote) {
-    margin-block-start: var(--space-l);
-}
-
-:where(h1, h2, h3) + p {
+:where(p, ul, ol, dl, blockquote) + :where(p, ul, ol, dl, blockquote) {
     margin-block-start: var(--space-l);
 }


### PR DESCRIPTION
## Summary
- move global heading styles to Heading component
- prune heading selectors from `_typography.scss`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0fd1de1c83288ecd6254aaf3cfce