### PR TITLE
fix: update prop enum lookup path

### DIFF
--- a/scripts/check-props.ts
+++ b/scripts/check-props.ts
@@ -64,7 +64,12 @@ async function scanProps(root: string) {
     const extensions = [".ts", ".tsx"];
     const files = await collectFiles(root, extensions, ignore);
 
-    const enumsFile = path.join(root, "packages", "types", "props.ts");
+    let enumsFile = path.join(root, "types", "props.ts");
+    try {
+        await fs.access(enumsFile);
+    } catch {
+        enumsFile = path.join(root, "packages", "types", "props.ts");
+    }
     const sizeEnum = await loadEnum(enumsFile, "Size");
     const variantEnum = await loadEnum(enumsFile, "Variant");
 


### PR DESCRIPTION
## Summary
- resolve check-props false positives by reading enums from `types/props.ts`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`
- `npm run check:props`


------
https://chatgpt.com/codex/tasks/task_e_68ab1b3ed48483289883335ce8847671