### PR TITLE
refactor: centralize metadata generation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,33 +1,17 @@
-import type { Metadata } from "next";
 import Image from "next/image";
 import Contact from "@/components/Contact/Contact";
 import Footer from "@/components/Footer/Footer";
 import Heading from "@/components/Heading/Heading";
 import Section from "@/components/Section/Section";
+import { buildMetadata } from "@/lib/metadata";
 import styles from "./page.module.scss";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "About",
     description:
         "Brett Dorrans' journey as a frontend engineer and design systems specialist.",
-    alternates: { canonical: "/about" },
-    openGraph: {
-        title: "About",
-        description:
-            "Brett Dorrans' journey as a frontend engineer and design systems specialist.",
-        url: "/about",
-        type: "website",
-        images: [{ url: "/opengraph-image" }],
-        siteName: "Lapidist",
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: "About",
-        description:
-            "Brett Dorrans' journey as a frontend engineer and design systems specialist.",
-        images: ["/twitter-image"],
-    },
-};
+    canonical: "/about",
+});
 
 export default function AboutPage() {
     return (

--- a/app/accessibility-statement/page.tsx
+++ b/app/accessibility-statement/page.tsx
@@ -1,14 +1,14 @@
-import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Container from "@/components/Container/Container";
 import Footer from "@/components/Footer/Footer";
 import Heading from "@/components/Heading/Heading";
+import { buildMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Accessibility Statement",
     description: "Commitment to an accessible web experience.",
-    alternates: { canonical: "/accessibility-statement" },
-};
+    canonical: "/accessibility-statement",
+});
 
 export default function AccessibilityStatementPage() {
     return (

--- a/app/ai-ethics-statement/page.tsx
+++ b/app/ai-ethics-statement/page.tsx
@@ -1,14 +1,14 @@
-import type { Metadata } from "next";
 import Contact from "@/components/Contact/Contact";
 import Container from "@/components/Container/Container";
 import Footer from "@/components/Footer/Footer";
 import Heading from "@/components/Heading/Heading";
+import { buildMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "AI Ethics Statement",
     description: "How I use AI responsibly in my work.",
-    alternates: { canonical: "/ai-ethics-statement" },
-};
+    canonical: "/ai-ethics-statement",
+});
 
 export default function AIEthicsStatementPage() {
     return (

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import Link from "next/link";
 import Card from "@/components/Card/Card";
 import Contact from "@/components/Contact/Contact";
@@ -6,31 +5,16 @@ import Footer from "@/components/Footer/Footer";
 import Section from "@/components/Section/Section";
 import { getAllArticles } from "@/lib/articles";
 import { formatDate } from "@/lib/date";
+import { buildMetadata } from "@/lib/metadata";
 import { Variant } from "@/types";
 import styles from "./page.module.scss";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Articles",
     description:
         "Articles and insights on front-end engineering and design systems.",
-    alternates: { canonical: "/articles" },
-    openGraph: {
-        title: "Articles",
-        description:
-            "Articles and insights on front-end engineering and design systems.",
-        url: "/articles",
-        type: "website",
-        images: [{ url: "/opengraph-image" }],
-        siteName: "Lapidist",
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: "Articles",
-        description:
-            "Articles and insights on front-end engineering and design systems.",
-        images: ["/twitter-image"],
-    },
-};
+    canonical: "/articles",
+});
 
 export default async function ArticlesPage() {
     const articles = await getAllArticles();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import Script from "next/script";
 import Approach from "@/components/Approach/Approach";
 import Contact from "@/components/Contact/Contact";
@@ -10,29 +9,21 @@ import Testimonials from "@/components/Testimonials/Testimonials";
 import TrustedBy from "@/components/TrustedBy/TrustedBy";
 import WhatIBring from "@/components/WhatIBring/WhatIBring";
 import { getAllArticles } from "@/lib/articles";
+import { buildMetadata } from "@/lib/metadata";
 import { buildHomePageStructuredData } from "@/lib/structured-data";
 
 const DESCRIPTION =
     "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.";
-
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     description: DESCRIPTION,
-    alternates: { canonical: "/" },
+    canonical: "/",
     openGraph: {
         title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
-        description: DESCRIPTION,
-        url: "/",
-        type: "website",
-        images: [{ url: "/opengraph-image" }],
-        siteName: "Lapidist",
     },
     twitter: {
-        card: "summary_large_image",
         title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
-        description: DESCRIPTION,
-        images: ["/twitter-image"],
     },
-};
+});
 
 export default async function Page() {
     const allArticles = await getAllArticles();

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+
+const SITE_NAME = "Lapidist";
+const DEFAULT_OG_IMAGE = "/opengraph-image";
+const DEFAULT_TWITTER_IMAGE = "/twitter-image";
+
+type OpenGraph = NonNullable<Metadata["openGraph"]>;
+type Twitter = NonNullable<Metadata["twitter"]>;
+
+export interface BuildMetadataOptions {
+    title?: string;
+    description: string;
+    canonical: string;
+    openGraph?: Partial<OpenGraph>;
+    twitter?: Partial<Twitter>;
+}
+
+export function buildMetadata({
+    title,
+    description,
+    canonical,
+    openGraph,
+    twitter,
+}: BuildMetadataOptions): Metadata {
+    const og: OpenGraph = {
+        title,
+        description,
+        url: canonical,
+        type: "website",
+        images: [{ url: DEFAULT_OG_IMAGE }],
+        siteName: SITE_NAME,
+        ...openGraph,
+    };
+
+    const tw: Twitter = {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [DEFAULT_TWITTER_IMAGE],
+        ...twitter,
+    };
+
+    return {
+        ...(title && { title }),
+        description,
+        alternates: { canonical },
+        openGraph: og,
+        twitter: tw,
+    };
+}


### PR DESCRIPTION
## Summary
- add reusable `buildMetadata` helper for page metadata
- replace per-page metadata objects with helper calls

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab36c93dbc83288cced25c3be76bb8