### PR TITLE
feat: centralize metadata

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -1,31 +1,15 @@
-import type { Metadata } from "next";
 import Image from "next/image";
 import Heading from "@/components/Heading/Heading";
 import Section from "@/components/Section/Section";
+import { buildMetadata } from "@/lib/metadata";
 import styles from "./page.module.scss";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "About",
     description:
         "Brett Dorrans' journey as a frontend engineer and design systems specialist.",
-    alternates: { canonical: "/about" },
-    openGraph: {
-        title: "About",
-        description:
-            "Brett Dorrans' journey as a frontend engineer and design systems specialist.",
-        url: "/about",
-        type: "website",
-        images: [{ url: "/opengraph-image" }],
-        siteName: "Lapidist",
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: "About",
-        description:
-            "Brett Dorrans' journey as a frontend engineer and design systems specialist.",
-        images: ["/twitter-image"],
-    },
-};
+    canonical: "/about",
+});
 
 export default function AboutPage() {
     return (

--- a/app/(site)/accessibility-statement/page.tsx
+++ b/app/(site)/accessibility-statement/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from "next";
 import Container from "@/components/Container/Container";
 import Heading from "@/components/Heading/Heading";
+import { buildMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Accessibility Statement",
     description: "Commitment to an accessible web experience.",
-    alternates: { canonical: "/accessibility-statement" },
-};
+    canonical: "/accessibility-statement",
+});
 
 export default function AccessibilityStatementPage() {
     return (

--- a/app/(site)/ai-ethics-statement/page.tsx
+++ b/app/(site)/ai-ethics-statement/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from "next";
 import Container from "@/components/Container/Container";
 import Heading from "@/components/Heading/Heading";
+import { buildMetadata } from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "AI Ethics Statement",
     description: "How I use AI responsibly in my work.",
-    alternates: { canonical: "/ai-ethics-statement" },
-};
+    canonical: "/ai-ethics-statement",
+});
 
 export default function AIEthicsStatementPage() {
     return (

--- a/app/(site)/articles/[year]/[slug]/page.tsx
+++ b/app/(site)/articles/[year]/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import Link from "next/link";
 import Script from "next/script";
 import AudioPlayer from "@/components/AudioPlayer/AudioPlayer";
@@ -6,6 +5,7 @@ import Section from "@/components/Section/Section";
 import TableOfContents from "@/components/TableOfContents/TableOfContents";
 import { getAllArticles, getArticle } from "@/lib/articles";
 import { formatDate } from "@/lib/date";
+import { buildMetadata } from "@/lib/metadata";
 import { buildArticleStructuredData } from "@/lib/structured-data";
 import styles from "./page.module.scss";
 
@@ -73,31 +73,24 @@ export async function generateMetadata({
     params,
 }: {
     params: Promise<{ year: string; slug: string }>;
-}): Promise<Metadata> {
+}) {
     const { year, slug } = await params;
     const { meta } = await getArticle(year, slug);
-    const base = "https://lapidist.net";
-    const url = `${base}/articles/${year}/${slug}/`;
+    const canonical = `/articles/${year}/${slug}`;
     const ogImage = `/articles/${year}/${slug}/opengraph-image`;
     const twitterImage = `/articles/${year}/${slug}/twitter-image`;
-    return {
+    return buildMetadata({
         title: meta.title,
         description: meta.description,
-        alternates: { canonical: url },
+        canonical,
         openGraph: {
-            title: meta.title,
-            description: meta.description,
-            url,
             type: "article",
             publishedTime: meta.date,
             images: [{ url: ogImage }],
             authors: meta.author.url ? [meta.author.url] : undefined,
         },
         twitter: {
-            card: "summary_large_image",
-            title: meta.title,
-            description: meta.description,
             images: [twitterImage],
         },
-    };
+    });
 }

--- a/app/(site)/articles/page.tsx
+++ b/app/(site)/articles/page.tsx
@@ -1,34 +1,18 @@
-import type { Metadata } from "next";
 import Link from "next/link";
 import Card from "@/components/Card/Card";
 import Section from "@/components/Section/Section";
 import { getAllArticles } from "@/lib/articles";
 import { formatDate } from "@/lib/date";
+import { buildMetadata } from "@/lib/metadata";
 import { Variant } from "@/types";
 import styles from "./page.module.scss";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Articles",
     description:
         "Articles and insights on front-end engineering and design systems.",
-    alternates: { canonical: "/articles" },
-    openGraph: {
-        title: "Articles",
-        description:
-            "Articles and insights on front-end engineering and design systems.",
-        url: "/articles",
-        type: "website",
-        images: [{ url: "/opengraph-image" }],
-        siteName: "Lapidist",
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: "Articles",
-        description:
-            "Articles and insights on front-end engineering and design systems.",
-        images: ["/twitter-image"],
-    },
-};
+    canonical: "/articles",
+});
 
 export default async function ArticlesPage() {
     const articles = await getAllArticles();

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import Script from "next/script";
 import Approach from "@/components/Approach/Approach";
 import Hero from "@/components/Hero/Hero";
@@ -8,29 +7,16 @@ import Testimonials from "@/components/Testimonials/Testimonials";
 import TrustedBy from "@/components/TrustedBy/TrustedBy";
 import WhatIBring from "@/components/WhatIBring/WhatIBring";
 import { getAllArticles } from "@/lib/articles";
+import { buildMetadata } from "@/lib/metadata";
 import { buildHomePageStructuredData } from "@/lib/structured-data";
 
 const DESCRIPTION =
     "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     description: DESCRIPTION,
-    alternates: { canonical: "/" },
-    openGraph: {
-        title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
-        description: DESCRIPTION,
-        url: "/",
-        type: "website",
-        images: [{ url: "/opengraph-image" }],
-        siteName: "Lapidist",
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: "Lead Frontend Engineer & Design Systems Specialist | Remote UK",
-        description: DESCRIPTION,
-        images: ["/twitter-image"],
-    },
-};
+    canonical: "/",
+});
 
 export default async function Page() {
     const allArticles = await getAllArticles();

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+
+interface BuildMetadataOptions {
+    /** Optional page title */
+    title?: string;
+    /** Page description */
+    description: string;
+    /** Canonical URL path, e.g. "/about" */
+    canonical: string;
+    /** Additional OpenGraph fields */
+    openGraph?: Metadata["openGraph"];
+    /** Additional Twitter fields */
+    twitter?: Metadata["twitter"];
+    /** Other metadata fields */
+    [key: string]: unknown;
+}
+
+export function buildMetadata({
+    title,
+    description,
+    canonical,
+    openGraph,
+    twitter,
+    ...rest
+}: BuildMetadataOptions): Metadata {
+    return {
+        ...(title && { title }),
+        description,
+        alternates: { canonical },
+        openGraph: {
+            ...(title && { title }),
+            description,
+            url: canonical,
+            type: "website",
+            ...openGraph,
+        },
+        twitter: {
+            card: "summary_large_image",
+            ...(title && { title }),
+            description,
+            ...twitter,
+        },
+        ...rest,
+    };
+}


### PR DESCRIPTION
## Summary
- add helper to build page metadata
- refactor pages to use centralized metadata builder

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ac5ef6883289026b68b5138ada6