### PR TITLE
align heading sizes with design tokens

### DIFF
--- a/components/Heading/Heading.module.scss
+++ b/components/Heading/Heading.module.scss
@@ -1,10 +1,19 @@
 .heading {
     font-family: var(--font-header), sans-serif;
     font-weight: var(--font-weight-semibold);
-    line-height: var(--typography-line-tight);
+    line-height: var(--typography-line-wide);
     margin-block: 0;
     margin-block-end: var(--space-xs);
     max-inline-size: var(--typography-measure);
+    text-wrap: balance;
+    hyphens: auto;
+    font-variation-settings:
+        "opsz" var(--typography-font-opsz),
+        "slnt" var(--typography-font-slnt);
+}
+
+.heading[id] {
+    scroll-margin-block-start: var(--space-2xl);
 }
 
 .heading[data-level="1"] {

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -63,38 +63,8 @@ svg {
     height: auto;
 }
 
-h1 {
-    font-size: var(--typography-size-400);
-}
-
-h2 {
-    font-size: var(--typography-size-300);
-}
-
-h3 {
-    font-size: var(--typography-size-200);
-}
-
 figure {
     margin: 0;
-}
-
-:where(h4, h5, h6) {
-    font-size: var(--typography-size-100);
-}
-
-:where(h1, h2, h3, h4, h5, h6) {
-    font-family: var(--font-header), sans-serif;
-    text-wrap: balance;
-    hyphens: auto;
-    line-height: var(--typography-line-wide);
-    font-variation-settings:
-        "opsz" var(--typography-font-opsz),
-        "slnt" var(--typography-font-slnt);
-}
-
-:where(h1, h2, h3, h4, h5, h6)[id] {
-    scroll-margin-block-start: var(--space-2xl);
 }
 
 :where(a:not([class])) {


### PR DESCRIPTION
## Summary
- move heading typography styles from global base stylesheet into Heading component
- keep size hierarchy using design-token variables and add scroll offset for anchored headings

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9926344c832896224d8881a0a3ca