### PR TITLE
build: exclude content mdx from storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,11 @@
 import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
-    stories: ["../**/*.stories.@(js|jsx|mjs|ts|tsx)", "../**/*.mdx"],
+    stories: [
+        "../**/*.stories.@(js|jsx|mjs|ts|tsx)",
+        "../**/*.mdx",
+        "!../content/**/*.mdx",
+    ],
     addons: ["@storybook/addon-a11y", "@storybook/addon-docs"],
 
     framework: {


### PR DESCRIPTION
## Summary
- prevent Storybook from indexing MDX files in `content`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9dab3afc8328a50dae52a68551d6