### PR TITLE
Fix Storybook build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,9 +2,10 @@ import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
     stories: [
-        "../**/*.stories.@(js|jsx|mjs|ts|tsx)",
-        "../**/*.mdx",
-        "!../content/**/*.mdx",
+        "../components/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+        "../components/**/*.mdx",
+        "../hooks/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+        "../hooks/**/*.mdx",
     ],
     addons: ["@storybook/addon-a11y", "@storybook/addon-docs"],
 


### PR DESCRIPTION
## Summary
- restrict Storybook MDX search to components and hooks

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`
- `npm run build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_68abbb4aeba883289bcc1df3c3773b97