### PR TITLE
refactor: simplify toggle styles

### DIFF
--- a/components/TableOfContents/TableOfContents.module.scss
+++ b/components/TableOfContents/TableOfContents.module.scss
@@ -18,34 +18,7 @@
 }
 
 .toggle {
-    @include inline-center;
-
-    min-block-size: var(--size-tap-min);
-    min-inline-size: var(--size-tap-min);
-    padding: var(--space-xs);
-    background: none;
-    border: none;
-    color: var(--colour-text);
-    cursor: pointer;
-    transition:
-        color var(--motion-dur-200) var(--motion-ease-standard),
-        transform var(--motion-dur-120) var(--motion-ease-emphasized);
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
-            color: var(--colour-primary);
-            transform: scale(1.1);
-        }
-
-        &:active {
-            transform: scale(0.95);
-        }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        transition: none;
-        transform: none;
-    }
+    @include icon-button;
 }
 
 .icon {
@@ -57,12 +30,6 @@
 
 .toggle[aria-expanded="false"] .icon {
     transform: rotate(180deg);
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .icon {
-        transition: none;
-    }
 }
 
 .content {
@@ -77,6 +44,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .toggle {
+        transition: none;
+        transform: none;
+    }
+
+    .icon,
     .content {
         transition: none;
     }
@@ -115,6 +88,15 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
+    .toggle:hover {
+        color: var(--colour-primary);
+        transform: scale(1.1);
+    }
+
+    .toggle:active {
+        transform: scale(0.95);
+    }
+
     .link:hover {
         text-decoration: underline;
     }

--- a/components/ThemeToggle/ThemeToggle.module.scss
+++ b/components/ThemeToggle/ThemeToggle.module.scss
@@ -1,34 +1,7 @@
 @use "../../styles/mixins" as *;
 
 .toggle {
-    @include inline-center;
-
-    min-block-size: var(--size-tap-min);
-    min-inline-size: var(--size-tap-min);
-    padding: var(--space-xs);
-    background: none;
-    border: none;
-    color: var(--colour-text);
-    cursor: pointer;
-    transition:
-        color var(--motion-dur-200) var(--motion-ease-standard),
-        transform var(--motion-dur-120) var(--motion-ease-emphasized);
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover {
-            color: var(--colour-primary);
-            transform: scale(1.1);
-        }
-
-        &:active {
-            transform: scale(0.95);
-        }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        transition: none;
-        transform: none;
-    }
+    @include icon-button;
 }
 
 .icon {
@@ -38,4 +11,26 @@
 
 .toggle[data-theme="dark"] .icon {
     transform: rotate(180deg);
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .toggle:hover {
+        color: var(--colour-primary);
+        transform: scale(1.1);
+    }
+
+    .toggle:active {
+        transform: scale(0.95);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .toggle {
+        transition: none;
+        transform: none;
+    }
+
+    .icon {
+        transition: none;
+    }
 }

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -112,3 +112,18 @@
 
     margin-block-start: var(--space-l);
 }
+
+@mixin icon-button {
+    @include inline-center;
+
+    min-block-size: var(--size-tap-min);
+    min-inline-size: var(--size-tap-min);
+    padding: var(--space-xs);
+    background: none;
+    border: none;
+    color: var(--colour-text);
+    cursor: pointer;
+    transition:
+        color var(--motion-dur-200) var(--motion-ease-standard),
+        transform var(--motion-dur-120) var(--motion-ease-emphasized);
+}


### PR DESCRIPTION
## Summary
- drop dedicated toggle-icon mixin and keep single icon-button helper
- apply icon-button to TableOfContents and ThemeToggle with local icon styling
- remove stylelint disables while keeping hover and reduced motion behavior

## Testing
- `npm run format`
- `npm run lint` *(fails: Unsafe call errors)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vitest/globals')*
- `npm run test:install-browsers`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac40ab9b588328ab726f71cd50343b