### PR TITLE
refactor: wrap Approach section in card

### DIFF
--- a/components/Approach/Approach.tsx
+++ b/components/Approach/Approach.tsx
@@ -1,5 +1,5 @@
 import Card from "@/components/Card/Card";
-import Section from "@/components/Section/Section";
+import Container from "@/components/Container/Container";
 import { Variant } from "@/types";
 import styles from "./Approach.module.scss";
 
@@ -35,44 +35,52 @@ interface Props {
 
 export default function Approach({ steps = DEFAULT_STEPS }: Props) {
     return (
-        <Section id="approach" heading="My approach">
-            <p>
-                Practical and collaborative, focused on turning complex frontend
-                challenges into clear, scalable systems. From assessment through
-                execution to governance, I ensure every decision is intentional
-                and every outcome supports long-term quality and impact.
-            </p>
-            <ol className={styles.steps}>
-                {steps.map(({ title, description }) => (
-                    <Card as="li" key={title} variant={Variant.Step}>
-                        <strong>{title}</strong>
-                        <p>{description}</p>
-                    </Card>
-                ))}
-            </ol>
-            <details>
-                <summary className={styles.summary}>
-                    Accessibility &amp; Performance pledge
-                </summary>
-                <dl className={styles.checklist}>
-                    <div>
-                        <dt>Keyboard-first:</dt>
-                        <dd>Every control works without a mouse.</dd>
-                    </div>
-                    <div>
-                        <dt>Contrast:</dt>
-                        <dd>Minimum 4.5:1 text contrast.</dd>
-                    </div>
-                    <div>
-                        <dt>Fast paint:</dt>
-                        <dd>95th percentile route paint &lt;1.2s.</dd>
-                    </div>
-                    <div>
-                        <dt>Motion aware:</dt>
-                        <dd>Animations off when you prefer less.</dd>
-                    </div>
-                </dl>
-            </details>
-        </Section>
+        <Container>
+            <Card
+                as="section"
+                id="approach"
+                heading="My approach"
+                headingLevel={2}
+            >
+                <p>
+                    Practical and collaborative, focused on turning complex
+                    frontend challenges into clear, scalable systems. From
+                    assessment through execution to governance, I ensure every
+                    decision is intentional and every outcome supports long-term
+                    quality and impact.
+                </p>
+                <ol className={styles.steps}>
+                    {steps.map(({ title, description }) => (
+                        <Card as="li" key={title} variant={Variant.Step}>
+                            <strong>{title}</strong>
+                            <p>{description}</p>
+                        </Card>
+                    ))}
+                </ol>
+                <details>
+                    <summary className={styles.summary}>
+                        Accessibility &amp; Performance pledge
+                    </summary>
+                    <dl className={styles.checklist}>
+                        <div>
+                            <dt>Keyboard-first:</dt>
+                            <dd>Every control works without a mouse.</dd>
+                        </div>
+                        <div>
+                            <dt>Contrast:</dt>
+                            <dd>Minimum 4.5:1 text contrast.</dd>
+                        </div>
+                        <div>
+                            <dt>Fast paint:</dt>
+                            <dd>95th percentile route paint &lt;1.2s.</dd>
+                        </div>
+                        <div>
+                            <dt>Motion aware:</dt>
+                            <dd>Animations off when you prefer less.</dd>
+                        </div>
+                    </dl>
+                </details>
+            </Card>
+        </Container>
     );
 }


### PR DESCRIPTION
## Summary
- wrap Approach section in a Container and Card so the card supplies the "My approach" heading

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac89b4e2948328aaa5e17ec42e0aa7