### PR TITLE
docs: add Approach component docs

### DIFF
--- a/components/Approach/Approach.mdx
+++ b/components/Approach/Approach.mdx
@@ -1,0 +1,31 @@
+import { ArgTypes, Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
+import Approach from "./Approach";
+import * as ApproachStories from "./Approach.stories";
+
+<Meta of={ApproachStories} />
+
+# Approach
+
+Outlines the typical engagement flow from assessment through governance.
+
+## Default steps
+
+- **Assess:** Deep-dive current UI, tooling, and workflows.
+- **Align:** Co-create a roadmap with design and product leads.
+- **Execute:** Deliver tokens, components, contracts, and docs iteratively.
+- **Govern:** Bake metrics and review loops into CI for sustained quality.
+
+## Accessibility notes
+
+- Steps are rendered in an ordered list for assistive technologies.
+- The pledge section uses `<details>` and `<summary>` elements for accessible disclosure.
+
+<Canvas>
+    <Story of={ApproachStories.Default} />
+</Canvas>
+
+<Canvas>
+    <Story of={ApproachStories.CustomSteps} />
+</Canvas>
+
+<ArgTypes of={Approach} />


### PR DESCRIPTION
## Summary
- document Approach component with description, default steps, accessibility notes
- showcase Default and CustomSteps stories in MDX
- add ArgTypes table for `steps`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm run test:unit`
- `npm run test:e2e` *(fails: Module not found: Can't resolve 'fs')*


------
https://chatgpt.com/codex/tasks/task_e_68acd685e8b88328b01dc7924b915c9b