### PR TITLE
docs: add Background component story

### DIFF
--- a/components/Background/Background.mdx
+++ b/components/Background/Background.mdx
@@ -1,0 +1,16 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
+import * as BackgroundStories from "./Background.stories";
+
+<Meta of={BackgroundStories} />
+
+# Background
+
+Decorative SVG backdrop used across pages.
+
+## Performance considerations
+
+The SVG employs multiple filters and gradients which can be costly to render; keep it static and avoid using more than once per page.
+
+<Canvas>
+    <Story of={BackgroundStories.Default} />
+</Canvas>

--- a/components/Background/Background.stories.tsx
+++ b/components/Background/Background.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import Background from "./Background";
+
+const meta = {
+    title: "Components/Background",
+    component: Background,
+} satisfies Meta<typeof Background>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- add Background story with default render
- document Background usage and performance notes in MDX and embed the story

## Testing
- `npm run format` *(fails: package-lock.json parse error)*
- `npx prettier components/Background/Background.stories.tsx components/Background/Background.mdx --check --plugin=@ianvs/prettier-plugin-sort-imports`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: missing swc dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68acd695925883288f2d3508a9e59847