### PR TITLE
fix: remove server action for static export

### DIFF
--- a/app/(site)/articles/[year]/[slug]/opengraph-image.tsx
+++ b/app/(site)/articles/[year]/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { getAllArticles, getArticle } from "@/utils";
+import { getAllArticles, getArticle } from "@/utils/articles";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;

--- a/app/(site)/articles/[year]/[slug]/page.tsx
+++ b/app/(site)/articles/[year]/[slug]/page.tsx
@@ -2,13 +2,8 @@ import clsx from "clsx";
 import Link from "next/link";
 import Script from "next/script";
 import { AudioPlayer, Section, TableOfContents } from "@/components";
-import {
-    buildArticleStructuredData,
-    buildMetadata,
-    formatDate,
-    getAllArticles,
-    getArticle,
-} from "@/utils";
+import { buildArticleStructuredData, buildMetadata, formatDate } from "@/utils";
+import { getAllArticles, getArticle } from "@/utils/articles";
 import styles from "./page.module.scss";
 
 export const dynamicParams = false;

--- a/app/(site)/articles/[year]/[slug]/twitter-image.tsx
+++ b/app/(site)/articles/[year]/[slug]/twitter-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { getAllArticles, getArticle } from "@/utils";
+import { getAllArticles, getArticle } from "@/utils/articles";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;

--- a/app/(site)/articles/page.tsx
+++ b/app/(site)/articles/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { Card, Section } from "@/components";
 import { Variant } from "@/types";
-import { buildMetadata, formatDate, getAllArticles } from "@/utils";
+import { buildMetadata, formatDate } from "@/utils";
+import { getAllArticles } from "@/utils/articles";
 import styles from "./page.module.scss";
 
 export const metadata = buildMetadata({

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -9,11 +9,8 @@ import {
     TrustedBy,
     WhatIBring,
 } from "@/components";
-import {
-    buildHomePageStructuredData,
-    buildMetadata,
-    getAllArticles,
-} from "@/utils";
+import { buildHomePageStructuredData, buildMetadata } from "@/utils";
+import { getAllArticles } from "@/utils/articles";
 
 const DESCRIPTION =
     "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.";

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,5 +1,5 @@
 import { Feed } from "feed";
-import { getAllArticles } from "@/utils";
+import { getAllArticles } from "@/utils/articles";
 
 const BASE_URL = "https://lapidist.net";
 const SITE_TITLE =

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import type { MetadataRoute } from "next";
-import { getAllArticles } from "@/utils";
+import { getAllArticles } from "@/utils/articles";
 
 export const dynamic = "force-static";
 

--- a/utils/articles.tsx
+++ b/utils/articles.tsx
@@ -1,5 +1,3 @@
-"use server";
-
 import fs from "fs";
 import path from "path";
 import { cache, type ComponentPropsWithoutRef, type ReactNode } from "react";

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,4 +1,3 @@
-export * from "./articles";
 export * from "./date";
 export * from "./metadata";
 export * from "./site-links";


### PR DESCRIPTION
## Summary
- remove server action from article utilities
- import article helpers directly where needed

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aceb408c94832898b5a6b96aad69c3