### PR TITLE
Fix article overflow on narrow screens

### DIFF
--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -1,4 +1,5 @@
 .prose {
+    inline-size: 100%;
     max-inline-size: var(--size-measure-prose);
 }
 


### PR DESCRIPTION
## Summary
- ensure article prose respects container width on small screens

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf79778f08328b77afd5269034427