### PR TITLE
Restrict card hover to interactive variants

### DIFF
--- a/components/Card/Card.module.scss
+++ b/components/Card/Card.module.scss
@@ -25,25 +25,6 @@
     border: var(--border-width-m) solid var(--colour-primary);
 }
 
-.card:focus-within {
-    box-shadow: var(--shadow-elev-2);
-    background: var(--surface-level-1-hover);
-}
-
-@media (hover: hover) and (pointer: fine) {
-    .card:hover {
-        box-shadow: var(--shadow-elev-2);
-        transform: translateY(-1px);
-        background: var(--surface-level-1-hover);
-    }
-
-    .card:active {
-        box-shadow: var(--shadow-elev-3);
-        transform: translateY(1px);
-        background: var(--surface-level-1-active);
-    }
-}
-
 @media (prefers-reduced-motion: reduce) {
     .card {
         transition: none;
@@ -121,6 +102,28 @@
 
     p {
         margin: 0;
+    }
+}
+
+.card[data-variant="link"]:focus-within,
+.card[data-variant="step"]:focus-within {
+    box-shadow: var(--shadow-elev-2);
+    background: var(--surface-level-1-hover);
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .card[data-variant="link"]:hover,
+    .card[data-variant="step"]:hover {
+        box-shadow: var(--shadow-elev-2);
+        transform: translateY(-1px);
+        background: var(--surface-level-1-hover);
+    }
+
+    .card[data-variant="link"]:active,
+    .card[data-variant="step"]:active {
+        box-shadow: var(--shadow-elev-3);
+        transform: translateY(1px);
+        background: var(--surface-level-1-active);
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid hover styling on cards unless using `link` or `step` variants

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68acf771a0408328ba7ebcb4d06d414f