### PR TITLE
fix: wrap long article text on narrow screens

### DIFF
--- a/app/(site)/articles/[year]/[slug]/page.module.scss
+++ b/app/(site)/articles/[year]/[slug]/page.module.scss
@@ -2,6 +2,8 @@
 
 .article {
     @include grid-stack(var(--space-scale-075));
+
+    overflow-wrap: anywhere;
 }
 
 .summary {


### PR DESCRIPTION
## Summary
- prevent article content overflowing by allowing long strings to wrap inside the article container

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad081282c48328b4cc7601718d7697