### PR TITLE
fix: inline prism theme to avoid mis-served css

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Lexend_Deca, Roboto_Mono } from "next/font/google";
 import "@/styles/globals.scss";
-import "prismjs/themes/prism-tomorrow.css";
 import { Background, Header } from "@/components";
 
 const header = Lexend_Deca({

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -4,6 +4,7 @@
 @layer base {
     @include meta.load-css("base");
     @include meta.load-css("typography");
+    @include meta.load-css("../node_modules/prismjs/themes/prism-tomorrow.css");
 }
 
 @layer tokens {


### PR DESCRIPTION
## Summary
- inline prism-tomorrow theme in global styles
- remove prism theme import from layout

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68ad628caec08328873b1c9c36f7e698