### PR TITLE
Add Open Graph image to homepage metadata

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -14,10 +14,14 @@ import { getAllArticles } from "@/utils/articles";
 
 const DESCRIPTION =
     "Ship design systems teams love. I architect UI platforms, uplift engineering culture, and deliver accessible, high-performance products.";
+const OG_IMAGE = "/opengraph-image";
+const TWITTER_IMAGE = "/twitter-image";
 
 export const metadata = buildMetadata({
     description: DESCRIPTION,
     canonical: "/",
+    openGraph: { images: [{ url: OG_IMAGE }] },
+    twitter: { images: [TWITTER_IMAGE] },
 });
 
 export default async function Page() {


### PR DESCRIPTION
## Summary
- ensure homepage includes Open Graph and Twitter images for link previews

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7895b0fc83289dcb5dedf9604332