### PR TITLE
fix: lengthen article meta descriptions

### DIFF
--- a/content/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas.mdx
+++ b/content/articles/2025/scaling-react-typescript-and-api-contracts-in-regulated-saas.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Architecting a Modern Frontend Platform: Scaling React, TypeScript, and API Contracts in Regulated SaaS"
 date: 2025-08-19
-description: "Why frontend is the backbone of compliance, velocity, and resilience in regulated SaaS."
+description: "Explores how a well-architected frontend underpins compliance, developer velocity, and long-term resilience within highly regulated SaaS platforms."
 summary: "A blueprint for building modern frontend platforms that balance scale, compliance, and developer speed."
 image: "/opengraph-image"
 author:

--- a/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
+++ b/content/articles/2025/what-recovering-from-a-stroke-at-34-taught-me.mdx
@@ -1,7 +1,7 @@
 ---
 title: "What Recovering From a Stroke at 34 Taught Me About Work, Life, and Finding a Balance"
 date: 2025-08-17
-description: "Reflections on a stroke at 34 and how recovery reshaped my approach to work and health."
+description: "Reflections on suffering a stroke at 34, the recovery journey, and how it reshaped my priorities on work, wellbeing, and sustainable growth."
 summary: "Lessons on burnout, balance, and human-centred engineering learned through my recovery from a stroke in my thirties."
 image: "/opengraph-image"
 audio: "/audio/article_1.mp3"


### PR DESCRIPTION
## Summary
- expand stroke article description to provide >100 characters
- expand frontend platform article description for LinkedIn compatibility

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7a1b08ec8328a31a35e6552727d5