### PR TITLE
fix: load prism css correctly

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Lexend_Deca, Roboto_Mono } from "next/font/google";
 import "@/styles/globals.scss";
+import "prismjs/themes/prism-tomorrow.css";
 import { Background, Header } from "@/components";
 
 const header = Lexend_Deca({

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -4,7 +4,6 @@
 @layer base {
     @include meta.load-css("base");
     @include meta.load-css("typography");
-    @include meta.load-css("../node_modules/prismjs/themes/prism-tomorrow.css");
 }
 
 @layer tokens {


### PR DESCRIPTION
## Summary
- import Prism theme css in layout to ensure correct content type
- remove direct node_modules sass include

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad83d9d7b0832895554ec342406f73