### PR TITLE
feat: improve articles page metadata for social sharing

### DIFF
--- a/app/(site)/articles/page.tsx
+++ b/app/(site)/articles/page.tsx
@@ -5,11 +5,17 @@ import { buildMetadata, formatDate } from "@/utils";
 import { getAllArticles } from "@/utils/articles";
 import styles from "./page.module.scss";
 
+const DESCRIPTION =
+    "Explore detailed tutorials, opinions, and case studies on front-end engineering, design systems, accessibility, performance, and modern web development practices.";
+const OG_IMAGE = "/opengraph-image";
+const TWITTER_IMAGE = "/twitter-image";
+
 export const metadata = buildMetadata({
     title: "Articles",
-    description:
-        "Articles and insights on front-end engineering and design systems.",
+    description: DESCRIPTION,
     canonical: "/articles",
+    openGraph: { images: [{ url: OG_IMAGE }] },
+    twitter: { images: [TWITTER_IMAGE] },
 });
 
 export default async function ArticlesPage() {


### PR DESCRIPTION
## Summary
- add long description to articles page
- include Open Graph and Twitter images for articles page

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9a4a67548328a55264347a5ace44