### PR TITLE
fix: inline structured data script

### DIFF
--- a/app/(site)/articles/[year]/[slug]/page.tsx
+++ b/app/(site)/articles/[year]/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 import Link from "next/link";
-import Script from "next/script";
 import { AudioPlayer, Section, TableOfContents } from "@/components";
 import { buildArticleStructuredData, buildMetadata, formatDate } from "@/utils";
 import { getAllArticles, getArticle } from "@/utils/articles";
@@ -28,13 +27,13 @@ export default async function ArticlePage({
     );
     return (
         <>
-            <Script
+            <script
                 id="structured-data"
                 type="application/ld+json"
-                strategy="beforeInteractive"
-            >
-                {JSON.stringify(structuredData)}
-            </Script>
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(structuredData),
+                }}
+            />
             <Section heading={meta.title} headingLevel={1}>
                 <article className={clsx(styles.article, "prose", "flow")}>
                     {meta.summary && (

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,4 +1,3 @@
-import Script from "next/script";
 import {
     Approach,
     Hero,
@@ -33,13 +32,13 @@ export default async function Page() {
     const structuredData = buildHomePageStructuredData(datePublished);
     return (
         <>
-            <Script
+            <script
                 id="structured-data"
                 type="application/ld+json"
-                strategy="beforeInteractive"
-            >
-                {JSON.stringify(structuredData)}
-            </Script>
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(structuredData),
+                }}
+            />
             <Hero />
             <TrustedBy />
             <Section as="div" container={false} gap="var(--space-scale-400)">


### PR DESCRIPTION
## Summary
- inline structured data script tags to stop CSS chunks being output as scripts in production

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada6c9ef408328ae0f130b7e523af0