### PR TITLE
ci: run tests in Playwright container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     test:
         name: Test
         runs-on: ubuntu-latest
+        container: mcr.microsoft.com/playwright:v1.55.0-noble
 
         steps:
             - name: Checkout
@@ -32,27 +33,6 @@ jobs:
               run: npm ci
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-
-            # Resolve the Playwright package version to make cache keys stable and bust on upgrades
-            - name: Resolve Playwright version
-              id: pw
-              run: |
-                  V=$(node -e "const p=require('./package.json');const v=(p.devDependencies?.['@playwright/test']||p.dependencies?.['@playwright/test']||'unknown');process.stdout.write(v)")
-                  echo "version=$V" >> "$GITHUB_OUTPUT"
-
-            # Cache the shared browsers directory
-            - name: Cache Playwright browsers
-              uses: actions/cache@v4
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-
-                      ${{ runner.os }}-playwright-
-
-            # Install browsers (will no-op if cache hit)
-            - name: Install Playwright browsers
-              run: npx playwright install --with-deps
 
             - name: Lint
               run: npm run lint


### PR DESCRIPTION
## Summary
- run tests in Playwright Docker image to avoid manual browser installs

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers` *(fails: environment terminated)*
- `npm test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68add691762c8328b9ce60e52ef67faa