### PR TITLE
ci: run tests in Playwright container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
     test:
         name: Test
         runs-on: ubuntu-latest
+        container:
+            image: mcr.microsoft.com/playwright:v1.55.0-noble
+            options: --ipc=host
 
         steps:
             - name: Checkout
@@ -32,27 +35,6 @@ jobs:
               run: npm ci
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-
-            # Resolve the Playwright package version to make cache keys stable and bust on upgrades
-            - name: Resolve Playwright version
-              id: pw
-              run: |
-                  V=$(node -e "const p=require('./package.json');const v=(p.devDependencies?.['@playwright/test']||p.dependencies?.['@playwright/test']||'unknown');process.stdout.write(v)")
-                  echo "version=$V" >> "$GITHUB_OUTPUT"
-
-            # Cache the shared browsers directory
-            - name: Cache Playwright browsers
-              uses: actions/cache@v4
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-
-                      ${{ runner.os }}-playwright-
-
-            # Install browsers (will no-op if cache hit)
-            - name: Install Playwright browsers
-              run: npx playwright install --with-deps
 
             - name: Lint
               run: npm run lint

--- a/smoke-tests/home.spec.ts
+++ b/smoke-tests/home.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 
 test("home page is accessible", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
-    await expect(page.locator("h1")).toContainText("design systems");
+    await expect(page.locator("h1")).toContainText("Lead Frontend Engineer");
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
     const nav = await page.evaluate(


### PR DESCRIPTION
## Summary
- run tests in Playwright Docker image to avoid manual browser installs
- update home page smoke test for new heading text

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`
- `npm run qa`


------
https://chatgpt.com/codex/tasks/task_e_68add691762c8328b9ce60e52ef67faa