### PR TITLE
test: update home page heading text

### DIFF
--- a/smoke-tests/home.spec.ts
+++ b/smoke-tests/home.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 
 test("home page is accessible", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
-    await expect(page.locator("h1")).toContainText("design systems");
+    await expect(page.locator("h1")).toContainText("scalable UI");
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
     const nav = await page.evaluate(


### PR DESCRIPTION
## Summary
- adjust home page smoke test to expect "scalable UI" heading

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adea18de1c83288df98b6d8251f236