### PR TITLE
refactor: remove useId from Heading component

### DIFF
--- a/components/Heading/Heading.tsx
+++ b/components/Heading/Heading.tsx
@@ -1,5 +1,4 @@
 import type { ElementType, ReactNode } from "react";
-import { useId } from "react";
 import clsx from "clsx";
 import type { PolymorphicProps } from "@/types";
 import styles from "./Heading.module.scss";
@@ -23,7 +22,6 @@ export default function Heading<As extends ElementType = "h1">({
     children,
     ...rest
 }: HeadingProps<As>) {
-    const generatedId = useId();
     const Component: ElementType = as ?? (`h${String(level)}` as ElementType);
 
     const semantic =
@@ -33,7 +31,7 @@ export default function Heading<As extends ElementType = "h1">({
 
     return (
         <Component
-            id={id ?? generatedId}
+            id={id}
             data-level={level}
             className={clsx(
                 styles.heading,


### PR DESCRIPTION
## Summary
- remove `useId` hook and auto-generated IDs from `Heading` to keep it as a server component

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ce353948328b8262e9eeec431ba