### PR TITLE
refactor: load global styles via stylesheet

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata, Viewport } from "next";
 import { Lexend_Deca, Roboto_Mono } from "next/font/google";
-import "@/styles/globals.scss";
 import { Background, Header } from "@/components";
+
+const globalStylesHref = new URL("../styles/globals.scss", import.meta.url)
+    .href;
 
 const header = Lexend_Deca({
     variable: "--font-header",
@@ -99,6 +101,11 @@ export default function RootLayout({
                 <meta
                     name="apple-mobile-web-app-title"
                     content={METADATA.brand}
+                />
+                <link
+                    rel="stylesheet"
+                    href={globalStylesHref}
+                    precedence="default"
                 />
                 <link
                     rel="preconnect"


### PR DESCRIPTION
## Summary
- load `styles/globals.scss` using a static `<link>`
- drop side-effect import of global styles

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae0cd8c8f883289449d8b8bbc9cdd3