### PR TITLE
chore: remove Next.js cache step from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,6 @@ jobs:
             - name: Lint files
               run: npm run lint
 
-            - name: Restore Next.js cache
-              uses: actions/cache@v4
-              with:
-                  path: .next/cache
-                  key: ${{ runner.os }}-next-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-next-
-
             - name: Run build storybook
               run: npm run build-storybook
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,13 +75,5 @@ jobs:
             - name: Storybook a11y
               run: npm run test:storybook
 
-            - name: Restore Next.js cache
-              uses: actions/cache@v4
-              with:
-                  path: .next/cache
-                  key: ${{ runner.os }}-next-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-next-
-
             - name: Build app
               run: npm run build


### PR DESCRIPTION
## Summary
- remove Next.js cache step from test and release workflows

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers` *(fails: debconf warnings)*
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16aee7ec83289e6e55c2ec7297a1