### PR TITLE
fix: prevent theme flash

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -102,6 +102,27 @@ export default function RootLayout({
                     name="apple-mobile-web-app-title"
                     content={METADATA.brand}
                 />
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: `(() => {
+                            try {
+                                const stored = localStorage.getItem("theme");
+                                const prefersDark = window.matchMedia(
+                                    "(prefers-color-scheme: dark)",
+                                ).matches;
+                                const theme =
+                                    stored ?? (prefersDark ? "dark" : "light");
+                                document.documentElement.classList.remove(
+                                    "light",
+                                    "dark",
+                                );
+                                document.documentElement.classList.add(theme);
+                            } catch {
+                                /* no-op */
+                            }
+                        })();`,
+                    }}
+                />
                 <link
                     rel="stylesheet"
                     href={globalStylesHref}


### PR DESCRIPTION
## Summary
- ensure stored theme is applied before styles load to avoid light-mode flash

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1b1dc8f883288cab6bead9824c79