### PR TITLE
fix: correct article og image path

### DIFF
--- a/app/(site)/articles/[year]/[slug]/opengraph-image.tsx
+++ b/app/(site)/articles/[year]/[slug]/opengraph-image.tsx
@@ -12,6 +12,10 @@ const LOGO_COLORS = {
     yellow: "#e9ba4d",
 } as const;
 
+const BACKGROUND = "#0f172a";
+const FOREGROUND = "#f8fafc";
+const GRID_COLOR = "rgba(255,255,255,0.05)";
+
 function LogoLockup() {
     return (
         <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
@@ -58,12 +62,11 @@ export default async function OGImage({
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "space-between",
-                    background: "#000",
-                    color: "#fff",
+                    background: BACKGROUND,
+                    color: FOREGROUND,
                     padding: "80px",
-                    fontFamily: "sans-serif",
-                    backgroundImage:
-                        "linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px)",
+                    fontFamily: "system-ui, sans-serif",
+                    backgroundImage: `linear-gradient(${GRID_COLOR} 1px, transparent 1px), linear-gradient(90deg, ${GRID_COLOR} 1px, transparent 1px)`,
                     backgroundSize: "40px 40px",
                 }}
             >
@@ -73,6 +76,7 @@ export default async function OGImage({
                         fontSize: 56,
                         fontWeight: 700,
                         lineHeight: 1.2,
+                        color: LOGO_COLORS.blue,
                     }}
                 >
                     {meta.title}

--- a/app/(site)/articles/[year]/[slug]/page.tsx
+++ b/app/(site)/articles/[year]/[slug]/page.tsx
@@ -62,8 +62,8 @@ export async function generateMetadata({
     const { year, slug } = await params;
     const { meta } = await getArticle(year, slug);
     const canonical = `/articles/${year}/${slug}`;
-    const ogImage = `${canonical}/opengraph-image.png`;
-    const twitterImage = `${canonical}/twitter-image.png`;
+    const ogImage = `${canonical}/opengraph-image`;
+    const twitterImage = `${canonical}/twitter-image`;
     return buildMetadata({
         title: meta.title,
         description: meta.description,
@@ -71,11 +71,11 @@ export async function generateMetadata({
         openGraph: {
             type: "article",
             publishedTime: meta.date,
-            images: [{ url: ogImage }],
+            images: [{ url: meta.image || ogImage }],
             authors: meta.author.url ? [meta.author.url] : undefined,
         },
         twitter: {
-            images: [twitterImage],
+            images: [meta.image || twitterImage],
         },
     });
 }

--- a/app/(site)/articles/[year]/[slug]/twitter-image.tsx
+++ b/app/(site)/articles/[year]/[slug]/twitter-image.tsx
@@ -12,6 +12,10 @@ const LOGO_COLORS = {
     yellow: "#e9ba4d",
 } as const;
 
+const BACKGROUND = "#0f172a";
+const FOREGROUND = "#f8fafc";
+const GRID_COLOR = "rgba(255,255,255,0.05)";
+
 function LogoLockup() {
     return (
         <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
@@ -58,12 +62,11 @@ export default async function TwitterImage({
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "space-between",
-                    background: "#000",
-                    color: "#fff",
+                    background: BACKGROUND,
+                    color: FOREGROUND,
                     padding: "96px",
-                    fontFamily: "sans-serif",
-                    backgroundImage:
-                        "linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px)",
+                    fontFamily: "system-ui, sans-serif",
+                    backgroundImage: `linear-gradient(${GRID_COLOR} 1px, transparent 1px), linear-gradient(90deg, ${GRID_COLOR} 1px, transparent 1px)`,
                     backgroundSize: "40px 40px",
                 }}
             >
@@ -73,6 +76,7 @@ export default async function TwitterImage({
                         fontSize: 72,
                         fontWeight: 700,
                         lineHeight: 1.2,
+                        color: LOGO_COLORS.blue,
                     }}
                 >
                     {meta.title}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -10,6 +10,10 @@ const LOGO_COLORS = {
     yellow: "#e9ba4d",
 } as const;
 
+const BACKGROUND = "#0f172a";
+const FOREGROUND = "#f8fafc";
+const GRID_COLOR = "rgba(255,255,255,0.05)";
+
 function LogoLockup() {
     return (
         <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
@@ -44,17 +48,16 @@ export default function OGImage() {
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "space-between",
-                    background: "#000",
-                    color: "#fff",
+                    background: BACKGROUND,
+                    color: FOREGROUND,
                     padding: "80px",
-                    fontFamily: "sans-serif",
-                    backgroundImage:
-                        "linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px)",
+                    fontFamily: "system-ui, sans-serif",
+                    backgroundImage: `linear-gradient(${GRID_COLOR} 1px, transparent 1px), linear-gradient(90deg, ${GRID_COLOR} 1px, transparent 1px)`,
                     backgroundSize: "40px 40px",
                 }}
             >
                 <LogoLockup />
-                <span style={{ fontSize: 56 }}>
+                <span style={{ fontSize: 56, color: LOGO_COLORS.blue }}>
                     Ship design systems teams love.
                 </span>
             </div>

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -10,6 +10,10 @@ const LOGO_COLORS = {
     yellow: "#e9ba4d",
 } as const;
 
+const BACKGROUND = "#0f172a";
+const FOREGROUND = "#f8fafc";
+const GRID_COLOR = "rgba(255,255,255,0.05)";
+
 function LogoLockup() {
     return (
         <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
@@ -44,17 +48,16 @@ export default function TwitterImage() {
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "space-between",
-                    background: "#000",
-                    color: "#fff",
+                    background: BACKGROUND,
+                    color: FOREGROUND,
                     padding: "96px",
-                    fontFamily: "sans-serif",
-                    backgroundImage:
-                        "linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px)",
+                    fontFamily: "system-ui, sans-serif",
+                    backgroundImage: `linear-gradient(${GRID_COLOR} 1px, transparent 1px), linear-gradient(90deg, ${GRID_COLOR} 1px, transparent 1px)`,
                     backgroundSize: "40px 40px",
                 }}
             >
                 <LogoLockup />
-                <span style={{ fontSize: 72 }}>
+                <span style={{ fontSize: 72, color: LOGO_COLORS.blue }}>
                     Ship design systems teams love.
                 </span>
             </div>


### PR DESCRIPTION
## Summary
- point article metadata to per-article Open Graph and Twitter image routes so generated images include the article title
- refresh Open Graph and Twitter image designs with brand colors

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2f844b4083289c1e8ee44c2c9303