### PR TITLE
fix: convert CSS script tags after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "build:static": "npm run build && npm run export",
         "build:tokens": "style-dictionary build --config style-dictionary.config.mjs && prettier styles/tokens.css --write",
         "build:tokens:watch": "node scripts/build-tokens-watch.mjs",
+        "postbuild": "tsx scripts/fix-css-script-tags.ts",
         "lint": "npm run lint:js && npm run lint:styles",
         "lint:js": "eslint .",
         "lint:styles": "stylelint \"**/*.{css,scss}\" --ignore-path .gitignore",

--- a/scripts/fix-css-script-tags.ts
+++ b/scripts/fix-css-script-tags.ts
@@ -1,0 +1,31 @@
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const root = "out";
+const files: string[] = [];
+
+function walk(dir: string): void {
+    for (const d of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, d.name);
+        if (d.isDirectory()) walk(p);
+        else if (p.endsWith(".html")) files.push(p);
+    }
+}
+walk(root);
+
+const re = /<script([^>]*?)\s+src=('|")([^"']+\.css)\2[^>]*><\/script>/g;
+
+for (const f of files) {
+    const html = readFileSync(f, "utf8");
+    re.lastIndex = 0;
+    if (re.test(html)) {
+        re.lastIndex = 0;
+        const fixed = html.replace(
+            re,
+            (_match: string, _attrs: string, q: string, href: string) =>
+                `<link rel="preload" as="style" href=${q}${href}${q}><link rel="stylesheet" href=${q}${href}${q}>`,
+        );
+        writeFileSync(f, fixed);
+        console.log("Fixed CSS script tag in", f);
+    }
+}


### PR DESCRIPTION
## Summary
- convert built CSS `<script>` tags to proper stylesheet links
- hook conversion script into postbuild step

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae20e8065c83288ca51a6b2bd4912e