### PR TITLE
fix: restore hover and focus styles

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const nextConfig: NextConfig = {
         unoptimized: true,
     },
     experimental: {
-        cssChunking: "strict",
+        cssChunking: true,
     },
     ...(basePath ? { basePath } : {}),
 };


### PR DESCRIPTION
## Summary
- disable strict CSS chunking so hover and focus styles are preserved in production

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fc8ff39c8328b8ae0bf68cb0d08f