### PR TITLE
Disable prefetch for CV download

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -26,6 +26,7 @@ type AnchorProps = BaseProps &
     AnchorHTMLAttributes<HTMLAnchorElement> & {
         href: string;
         disabled?: boolean;
+        prefetch?: boolean;
     };
 
 type Props = ButtonProps | AnchorProps;
@@ -49,9 +50,10 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
         } as const;
 
         if (href) {
-            const { disabled, onClick, tabIndex, ...anchorRest } =
+            const { disabled, onClick, tabIndex, prefetch, ...anchorRest } =
                 rest as AnchorHTMLAttributes<HTMLAnchorElement> & {
                     disabled?: boolean;
+                    prefetch?: boolean;
                 };
 
             const commonProps = {
@@ -71,7 +73,11 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
 
             if (href.startsWith("/")) {
                 return (
-                    <Link {...commonProps} ref={ref as Ref<HTMLAnchorElement>}>
+                    <Link
+                        {...commonProps}
+                        prefetch={prefetch}
+                        ref={ref as Ref<HTMLAnchorElement>}
+                    >
                         {children}
                     </Link>
                 );

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -22,6 +22,7 @@ export default function Contact() {
                 <Button
                     href="/brett-dorrans-cv.pdf"
                     variant={Variant.Secondary}
+                    prefetch={false}
                 >
                     Download CV
                 </Button>

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -81,6 +81,7 @@ export default function Hero() {
                         href="/brett-dorrans-cv.pdf"
                         size={Size.LG}
                         variant={Variant.Secondary}
+                        prefetch={false}
                     >
                         Download my resume
                     </Button>


### PR DESCRIPTION
## Summary
- allow Button to pass `prefetch` through to Next.js `Link`
- disable prefetch for CV download buttons so Next.js no longer requests `brett-dorrans-cv.pdf.txt`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:install-browsers`
- `npm test` *(fails: accessibility test in smoke-tests/home.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b572b457048328a32fa309cde6ab91