### PR TITLE
test: stabilize accessibility checks

### DIFF
--- a/smoke-tests/home.spec.ts
+++ b/smoke-tests/home.spec.ts
@@ -1,8 +1,18 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
-test("home page is accessible", async ({ page }) => {
+test("home page is accessible", async ({ page }, testInfo) => {
     await page.goto("/", { waitUntil: "networkidle" });
+
+    // wait for the theme class to be applied to the root element to avoid
+    // transient colour variable mismatches that can cause Axe to report
+    // contrast violations in CI
+    const theme = testInfo.project.name;
+    await page.waitForFunction(
+        (expected) => document.documentElement.classList.contains(expected),
+        theme,
+    );
+
     await expect(page.locator("h1")).toContainText("scalable UI");
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
     expect(accessibilityScanResults.violations).toEqual([]);


### PR DESCRIPTION
## Summary
- wait for the theme class before running accessibility scans to avoid transient contrast issues

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b573f6b96c832893ae6759046e9c7b